### PR TITLE
Fix failing end-to-end tests (italicized space bug, quoteblock second paragraph bug)

### DIFF
--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -285,13 +285,18 @@ class FencedCodeBlock(Block):
         return CodeBlock(('', language, []), self.rich_text.to_plain_text())
 
 
-class QuoteBlock(Block):
+class QuoteBlock(ParagraphBlock):
     def __init__(self, client, notion_data, page, get_children=True):
         super().__init__(client, notion_data, page, get_children)
         self.rich_text = client.wrap_notion_rich_text_array(self.notion_data["rich_text"])
 
     def to_pandoc(self):
-        return BlockQuote([Para(self.rich_text.to_pandoc())])
+        pandoc_ast = super().to_pandoc()
+        return (
+            BlockQuote(pandoc_ast)
+            if isinstance(pandoc_ast, list)
+            else BlockQuote([super().to_pandoc()])
+        )
 
 
 class FileBlock(Block):

--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -295,7 +295,7 @@ class QuoteBlock(ParagraphBlock):
         return (
             BlockQuote(pandoc_ast)
             if isinstance(pandoc_ast, list)
-            else BlockQuote([super().to_pandoc()])
+            else BlockQuote([pandoc_ast])
         )
 
 

--- a/n2y/rich_text.py
+++ b/n2y/rich_text.py
@@ -42,11 +42,13 @@ class RichText:
 
     def plain_text_to_pandoc(self):
         ast = []
-        match = re.findall(r"( +)|(\S+)|(\n+)|(\t+)", self.plain_text)
+        match = re.findall(r"( +)|(\xa0+)|(\S+)|(\n+)|(\t+)", self.plain_text)
 
         for m in match:
-            space, word, newline, tab = m
+            space, latin1_space, word, newline, tab = m
             for _ in range(len(space)):
+                ast.append(Space())
+            for _ in range(len(latin1_space)):
                 ast.append(Space())
             if word:
                 ast.append(Str(word))

--- a/n2y/rich_text.py
+++ b/n2y/rich_text.py
@@ -45,10 +45,10 @@ class RichText:
         match = re.findall(r"( +)|(\xa0+)|(\S+)|(\n+)|(\t+)", self.plain_text)
 
         for m in match:
-            space, latin1_space, word, newline, tab = m
+            space, non_breaking_space, word, newline, tab = m
             for _ in range(len(space)):
                 ast.append(Space())
-            for _ in range(len(latin1_space)):
+            for _ in range(len(non_breaking_space)):
                 ast.append(Space())
             if word:
                 ast.append(Str(word))


### PR DESCRIPTION
Closes https://github.com/innolitics/n2y/issues/46

Fixes the two failing asserts in the end-to-end test
1. It looks like Notion encodes spaces in Latin1 (strangely this has only appeared now with italicized words?), so we need to make sure we append Space()s for them like we do for utf-8 spaces. 
2. QuoteBlocks can have children and right now the to_pandoc() method for it doesn't handle that. I made it handle that by extending the ParagraphBlock (because the QuoteBlock is effectively just a ParagraphBlock wrapped in quotes).