### PR TITLE
Fix a bug in the audit system

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ pytest tests
 
 Here are some features we're planning to add in the future:
 
-- Add support for all block types
 - Make the plugin system more fully featured and easier to use
 - Add support for recursively dumping sets of pages and preserving links between them
 - Add some sort of Notion API caching mechanism
@@ -229,6 +228,8 @@ Here are some features we're planning to add in the future:
 - Add `n2y.plugins.footnotes` plugin
 - Add support for exporting HTML files (useful for generating jekyll pages or if you need pandoc features that aren't supported in github flavored markdown).
 - Added the `n2yaudit` tool.
+- Added support for the column block types.
+- Added basic support the link to page block type.
 
 ### v0.4.2
 

--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -570,8 +570,24 @@ class SyncedBlock(Block):
         return self.children_to_pandoc()
 
 
-class LinkToPageBlock(WarningBlock):
-    pass
+class LinkToPageBlock(Block):
+    def __init__(self, client, notion_data, page, get_children=True):
+        super().__init__(client, notion_data, page, get_children)
+        self.link_type = self.notion_data["type"]
+        self.link_notion_id = self.notion_data[self.link_type]
+
+    def to_pandoc(self):
+        # TODO: in the future, if we are exporting the linked page too, then add
+        # a link to the page. For now, we just display the text of the page.
+        if self.link_type == "page_id":
+            page = self.client.get_page(self.link_notion_id)
+            title = page.title.to_pandoc()
+        elif self.link_type == "database_id":
+            database = self.client.get_database(self.link_notion_id)
+            title = database.title.to_pandoc()
+        else:
+            raise Exception(f"Unknown link type '{self.link_type}'")
+        return Para(title)
 
 
 def render_with_caption(content_ast, caption_ast):

--- a/n2y/database.py
+++ b/n2y/database.py
@@ -110,22 +110,10 @@ class Database:
 
     def to_yaml(self):
         content_property = self.client.content_property
-        id_property = self.client.id_property
-        url_property = self.client.url_property
         if content_property in self.schema:
             logger.warning(
                 'The content property "%s" is shadowing an existing '
                 'property with the same name', content_property,
-            )
-        if id_property in self.schema:
-            logger.warning(
-                'The id property "%s" is shadowing an existing '
-                'property with the same name', id_property,
-            )
-        if url_property in self.schema:
-            logger.warning(
-                'The url property "%s" is shadowing an existing '
-                'property with the same name', url_property,
             )
         results = []
         for page in self.children:
@@ -133,10 +121,5 @@ class Database:
             if content_property:
                 content = page.content_to_markdown()
                 result[content_property] = content
-            if id_property:
-                notion_id = page.notion_id
-                result[id_property] = notion_id
-            if url_property:
-                result[url_property] = page.notion_url
             results.append(result)
         return yaml.dump(results, sort_keys=False)

--- a/n2y/main.py
+++ b/n2y/main.py
@@ -44,15 +44,11 @@ def main(raw_args, access_token):
             "Only applies when dumping a database to YAML."
         )
     )
-    # TODO: Consider making id-property and url-property available when dumping
-    # to markdown files, and not just when dumping to YAML; if we do this, we
-    # should probably move some code out of Database.to_yaml into the Page
     parser.add_argument(
         "--id-property", default='id',
         help=(
             "Store each database page's id in this property. "
             "The page's id isn't exported if it's set to a blank string. "
-            "Only applies when dumping a database to YAML."
         )
     )
     parser.add_argument(
@@ -60,7 +56,6 @@ def main(raw_args, access_token):
         help=(
             "Store each database page's url in this property. "
             "The page's id isn't exported if it's set to a blank string. "
-            "Only applies when dumping a database to YAML."
         )
     )
     parser.add_argument(

--- a/n2y/mentions.py
+++ b/n2y/mentions.py
@@ -1,4 +1,5 @@
 from pandoc.types import Str
+from n2y.blocks import RowBlock
 
 from n2y.utils import process_notion_date, processed_date_to_plain_text
 
@@ -22,6 +23,12 @@ class UserMention(Mention):
 
 class PageMention(Mention):
     def __init__(self, client, notion_data, plain_text, block=None):
+        # workaround for a bug in the Notion API wheren the plain_text is
+        # untitled inside simple tables
+        if plain_text == "Untitled" and isinstance(block, RowBlock):
+            page = client.get_page(notion_data["page"]["id"])
+            plain_text = page.title.to_plain_text()
+
         super().__init__(client, notion_data, plain_text, block)
         self.notion_page_id = notion_data["page"]["id"]
 

--- a/n2y/mentions.py
+++ b/n2y/mentions.py
@@ -27,7 +27,8 @@ class PageMention(Mention):
         # untitled inside simple tables
         if plain_text == "Untitled" and isinstance(block, RowBlock):
             page = client.get_page(notion_data["page"]["id"])
-            plain_text = page.title.to_plain_text()
+            if page is not None:
+                plain_text = page.title.to_plain_text()
 
         super().__init__(client, notion_data, plain_text, block)
         self.notion_page_id = notion_data["page"]["id"]

--- a/n2y/page.py
+++ b/n2y/page.py
@@ -109,7 +109,27 @@ class Page:
             return None
 
     def properties_to_values(self):
-        return {k: v.to_value() for k, v in self.properties.items()}
+        properties = {k: v.to_value() for k, v in self.properties.items()}
+
+        id_property = self.client.id_property
+        if id_property in properties:
+            logger.warning(
+                'The id property "%s" is shadowing an existing '
+                'property with the same name', id_property,
+            )
+        if id_property:
+            notion_id = self.notion_id
+            properties[id_property] = notion_id
+
+        url_property = self.client.url_property
+        if url_property in properties:
+            logger.warning(
+                'The url property "%s" is shadowing an existing '
+                'property with the same name', url_property,
+            )
+        if url_property:
+            properties[url_property] = self.notion_url
+        return properties
 
     def to_markdown(self):
         return '\n'.join([

--- a/n2y/page.py
+++ b/n2y/page.py
@@ -39,7 +39,7 @@ class Page:
     @property
     def title(self):
         for property_value in self.properties.values():
-            # Notion ensure's there is always exactly one title property
+            # Notion ensures there is always exactly one title property
             if isinstance(property_value, TitlePropertyValue):
                 return property_value.rich_text
 

--- a/n2y/page.py
+++ b/n2y/page.py
@@ -51,6 +51,9 @@ class Page:
 
     @property
     def children(self):
+        """
+        Get a list of child pages and databases.
+        """
         if self._children is None:
             self._children = []
             for block in self.block.children:
@@ -64,6 +67,10 @@ class Page:
         elif isinstance(block, ChildDatabaseBlock):
             database = self.client.get_database(block.notion_id)
             self._children.append(database)
+        elif block.children is not None:
+            # Recursively look for child pages and databases in the hierarchy
+            for child_block in block.children:
+                self._append_children(child_block)
 
     @property
     def parent(self):

--- a/n2y/rich_text.py
+++ b/n2y/rich_text.py
@@ -111,7 +111,8 @@ class MentionRichText(RichText):
     def __init__(self, client, notion_data, block=None):
         super().__init__(client, notion_data, block)
         self.mention = client.wrap_notion_mention(
-            notion_data['mention'], notion_data["plain_text"], block)
+            notion_data['mention'], notion_data["plain_text"], block,
+        )
 
     def to_pandoc(self):
         if self.code:

--- a/tests/test_audit_end_to_end.py
+++ b/tests/test_audit_end_to_end.py
@@ -5,7 +5,7 @@ from tests.utils import NOTION_ACCESS_TOKEN
 from n2y.audit import main
 
 
-def run_n2y(arguments):
+def run_n2yaudit(arguments):
     old_stdout = sys.stdout
     old_stderr = sys.stderr
     sys.stdout = StringIO()
@@ -26,7 +26,7 @@ def test_audit():
     https://fresh-pencil-9f3.notion.site/Audited-cfa8ff07bba244c8b967c9b6a7a954c1
     '''
     object_id = 'cfa8ff07bba244c8b967c9b6a7a954c1'
-    status, stdoutput, _ = run_n2y([object_id])
+    status, stdoutput, _ = run_n2yaudit([object_id])
     assert status == 3
 
     external_link_in_top_page = \
@@ -37,8 +37,11 @@ def test_audit():
         'https://www.notion.so/Child-f3e3628fc80c470ea68994fa7ec0ff17#eab91ccc32924221ac3f0a74225a33dd'  # noqa: E501
     external_link_in_child_database = \
         'https://www.notion.so/B-4412005dcec24ff2827abbc367c90b29#6373a0b5c2804fbe9dfac167ce6948a0'  # noqa: E501
+    link_to_local_page_in_database_in_column = \
+        'https://www.notion.so/Audited-cfa8ff07bba244c8b967c9b6a7a954c1#21a13c06ef86462e882a181c6cb52a64'  # noqa: E501
 
     assert external_link_in_top_page in stdoutput
     assert external_link_in_child_page in stdoutput
     assert internal_link_in_child_page not in stdoutput
     assert external_link_in_child_database in stdoutput
+    assert link_to_local_page_in_database_in_column not in stdoutput

--- a/tests/test_audit_end_to_end.py
+++ b/tests/test_audit_end_to_end.py
@@ -29,19 +29,31 @@ def test_audit():
     status, stdoutput, _ = run_n2yaudit([object_id])
     assert status == 3
 
-    external_link_in_top_page = \
+    external_mention_in_top_page = \
         'https://www.notion.so/Audited-cfa8ff07bba244c8b967c9b6a7a954c1#aa4fa886f8244c818de8018bb3491806'  # noqa: E501
-    external_link_in_child_page = \
+    external_mention_in_child_page = \
         'https://www.notion.so/Child-f3e3628fc80c470ea68994fa7ec0ff17#d1d32ff6f0cb4c71a2f1c4ec55e00086'  # noqa: E501
-    internal_link_in_child_page = \
+    internal_mention_in_child_page = \
         'https://www.notion.so/Child-f3e3628fc80c470ea68994fa7ec0ff17#eab91ccc32924221ac3f0a74225a33dd'  # noqa: E501
-    external_link_in_child_database = \
+    external_mention_in_child_database = \
         'https://www.notion.so/B-4412005dcec24ff2827abbc367c90b29#6373a0b5c2804fbe9dfac167ce6948a0'  # noqa: E501
-    link_to_local_page_in_database_in_column = \
+    internal_mention_in_database_in_column = \
         'https://www.notion.so/Audited-cfa8ff07bba244c8b967c9b6a7a954c1#21a13c06ef86462e882a181c6cb52a64'  # noqa: E501
 
+    # NOTE: When you try to get a link for a "LinkToPageBlock" in the Notion UI,
+    # it appears to give you the URL for the linked page or database, and not to
+    # the block itself. Thus, these two links were extracted using a debugger
+    # when running this test.
+
+    external_link_in_top_page = \
+        'https://www.notion.so/Audited-cfa8ff07bba244c8b967c9b6a7a954c1#c22d76d50c704761b0e729531e6cc24b'  # noqa: E501
+    internal_link_in_top_page = \
+        'https://www.notion.so/Audited-cfa8ff07bba244c8b967c9b6a7a954c1#3e2e2fb2e9bf4a1f8b00bbb18a9d97e9'  # noqa: E501
+
+    assert external_mention_in_top_page in stdoutput
+    assert external_mention_in_child_page in stdoutput
+    assert internal_mention_in_child_page not in stdoutput
+    assert external_mention_in_child_database in stdoutput
+    assert internal_mention_in_database_in_column not in stdoutput
     assert external_link_in_top_page in stdoutput
-    assert external_link_in_child_page in stdoutput
-    assert internal_link_in_child_page not in stdoutput
-    assert external_link_in_child_database in stdoutput
-    assert link_to_local_page_in_database_in_column not in stdoutput
+    assert internal_link_in_top_page not in stdoutput

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -413,6 +413,16 @@ def test_scyned_block_unshared():
     assert unshared_reference_markdown == ""
 
 
+def test_link_to_page_page():
+    # TODO: add a unit test for a LinkToPageBlock pointing to a page
+    pass
+
+
+def test_link_to_page_database():
+    # TODO: add a unit test for a LinkToPageBlock pointing to a database
+    pass
+
+
 def test_column_block():
     column_block = mock_block("column", {}, has_children=True)
     children = [mock_paragraph_block([("child", [])])]

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -384,7 +384,7 @@ def test_callout():
     )
 
 
-def test_scyned_block_shared():
+def test_synced_block_shared():
     original_synced_block = mock_block(
         "synced_block",
         {"synced_from": None},
@@ -392,23 +392,28 @@ def test_scyned_block_shared():
     reference_synced_block = mock_block(
         "synced_block",
         {"synced_from": {'type': 'block_id', 'block_id': 'some-block-id'}},
-        has_children=True)
+        has_children=True,
+    )
     children = [mock_paragraph_block([("synced", [])])]
     original_pandoc_ast, original_markdown = process_parent_block(
-        original_synced_block, children)
+        original_synced_block, children,
+    )
     reference_pandoc_ast, reference_markdown = process_parent_block(
-        reference_synced_block, children)
+        reference_synced_block, children,
+    )
     assert original_pandoc_ast == reference_pandoc_ast == [Para([Str("synced")])]
     assert original_markdown == reference_markdown == "synced\n"
 
 
-def test_scyned_block_unshared():
+def test_synced_block_unshared():
     unshared_reference_synced_block = mock_block(
         "synced_block",
         {"synced_from": {'type': 'block_id', 'block_id': 'some-block-id'}},
-        has_children=False)
+        has_children=False,
+    )
     unshared_reference_pandoc_ast, unshared_reference_markdown = process_parent_block(
-        unshared_reference_synced_block, None)
+        unshared_reference_synced_block, None,
+    )
     assert unshared_reference_pandoc_ast is None
     assert unshared_reference_markdown == ""
 
@@ -435,7 +440,7 @@ def test_column_block():
         AlignDefault(),
         RowSpan(1),
         ColSpan(1),
-        [Para([Str('child')])]
+        [Para([Str('child')])],
     )
 
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -171,6 +171,17 @@ def test_all_properties_database():
     assert len(unsorted_database) == 4
 
 
+def test_mention_in_simple_table(tmp_path):
+    '''
+    The page can be seen here:
+    https://fresh-pencil-9f3.notion.site/Simple-Table-with-Mention-Test-e12497428b0e43c3b14e016de6c5a2cf
+    '''
+    object_id = 'e12497428b0e43c3b14e016de6c5a2cf'
+    _, document_as_markdown, _ = run_n2y([object_id, '--media-root', str(tmp_path)])
+    assert "In Table: Simple Test Page" in document_as_markdown
+    assert "Out of Table: Simple Test Page" in document_as_markdown
+
+
 def test_all_blocks_page_to_markdown(tmp_path):
     '''
     The page can be seen here:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -224,6 +224,10 @@ def test_all_blocks_page_to_markdown(tmp_path):
     assert lines.count("This is a synced block.") == 2
     assert "This is a synced block from another page." in lines
     assert all(column_strings_in_lines) or (column_string in lines)
+    assert "Mention: Simple Test Page" in lines
+    assert "Simple Test Page" in lines  # from the LinkToPageBlock
+    assert "Mention: Simple Test Database" in lines
+    assert "Simple Test Database" in lines  # from the LinkToPageBlock
 
     # a bookmark with a caption and without
     assert "<https://innolitics.com>" in lines


### PR DESCRIPTION
The `Page.children` property was not recursing into child blocks and as a result any child database or page that was not a top-level block would be picked up by the audit system.

This bug would affect other things too, although it was noticed due to an audit producing false positives.