### PR TITLE
Upgrade Notion API to 2022-06-28

### DIFF
--- a/n2y/notion.py
+++ b/n2y/notion.py
@@ -85,7 +85,7 @@ class Client:
         self.headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
-            "Notion-Version": "2022-02-22",
+            "Notion-Version": "2022-06-28",
         }
 
         self.databases_cache = {}


### PR DESCRIPTION
The new API versions changes the following:
* ~Page properties must be retrieved using the page properties endpoint.~ (this no longer applies)
* Parents are now always direct parents; a parent field has been added to block. (this doesn't impact us)
* Database relations have a type of single_property and dual_property. (this doesn't impact us)

Tested it on one of our previous projects by running `make notion && make docs` before and after the API version change (with the same id_mappings.yml file) and then diffing the `data`, `documents`, and `img` directories. They were identical (`release` has diffs but that's not surprising since those consist docx and xlsx files)

Closes https://github.com/innolitics/n2y/issues/54


