### PR TITLE
Link to page block

### DIFF
--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -583,13 +583,13 @@ class LinkToPageBlock(Block):
         # TODO: in the future, if we are exporting the linked page too, then add
         # a link to the page. For now, we just display the text of the page.
 
-        page = self.client.get_page_or_database(self.linked_page_id)
-        if page is None:
-            msg = "Permission denied when attempting to access linked page [%s]"
+        node = self.client.get_page_or_database(self.linked_page_id)
+        if node is None:
+            msg = "Permission denied when attempting to access linked node [%s]"
             logger.warning(msg, self.notion_url)
             return None
         else:
-            title = page.title.to_pandoc()
+            title = node.title.to_pandoc()
             return Para(title)
 
 

--- a/n2y/notion_mocks.py
+++ b/n2y/notion_mocks.py
@@ -148,7 +148,7 @@ def mock_relation_value():
 
 def mock_page(title="Mock Title"):
 
-    # Returns a mock version the data that would be returned by 
+    # Returns a mock version the data that would be returned by
     # the Notion API on a client.get_page() request.
 
     user = mock_user()

--- a/n2y/notion_mocks.py
+++ b/n2y/notion_mocks.py
@@ -144,3 +144,48 @@ def mock_select_option(name, **kwargs):
 
 def mock_relation_value():
     return {"id": mock_id()}
+
+
+def mock_page(title = "Mock Title"):
+
+    # Returns the data that would have been returned by the Notion API 
+    # on a client.get_page() request.
+
+    user = mock_user()
+    created_time = datetime.now().isoformat()
+    notion_id = mock_id()
+    hyphenated_title = title.replace(" ", "-")
+
+    page_object = {
+    'object':'page',
+    'id':notion_id,
+    'created_time':created_time,
+    'last_edited_time':created_time,
+    'created_by':user,
+    'last_edited_by':user,
+    'cover': None,
+    'icon': None,
+    'parent':{'type':'page_id','page_id':mock_id()},
+    'archived': False,
+    'properties':{
+        'title':{
+            'id':'title',
+            'type':'title',
+            'title':[{
+                'type':'text','text':{'content':title,'link':None},
+                'annotations':{
+                    'bold':False,
+                    'italic':False,
+                    'strikethrough':False,
+                    'underline':False,
+                    'code':False,
+                    'color':'default'},
+                'plain_text':title,'href':None
+                }]
+                }
+                },
+    'url':f'https://www.notion.so/{hyphenated_title}-{notion_id}',
+    }
+
+    return page_object
+

--- a/n2y/notion_mocks.py
+++ b/n2y/notion_mocks.py
@@ -146,10 +146,10 @@ def mock_relation_value():
     return {"id": mock_id()}
 
 
-def mock_page(title = "Mock Title"):
+def mock_page(title="Mock Title"):
 
-    # Returns the data that would have been returned by the Notion API 
-    # on a client.get_page() request.
+    # Returns a mock version the data that would be returned by 
+    # the Notion API on a client.get_page() request.
 
     user = mock_user()
     created_time = datetime.now().isoformat()
@@ -157,35 +157,34 @@ def mock_page(title = "Mock Title"):
     hyphenated_title = title.replace(" ", "-")
 
     page_object = {
-    'object':'page',
-    'id':notion_id,
-    'created_time':created_time,
-    'last_edited_time':created_time,
-    'created_by':user,
-    'last_edited_by':user,
-    'cover': None,
-    'icon': None,
-    'parent':{'type':'page_id','page_id':mock_id()},
-    'archived': False,
-    'properties':{
-        'title':{
-            'id':'title',
-            'type':'title',
-            'title':[{
-                'type':'text','text':{'content':title,'link':None},
-                'annotations':{
-                    'bold':False,
-                    'italic':False,
-                    'strikethrough':False,
-                    'underline':False,
-                    'code':False,
-                    'color':'default'},
-                'plain_text':title,'href':None
+        'object': 'page',
+        'id': notion_id,
+        'created_time': created_time,
+        'last_edited_time': created_time,
+        'created_by': user,
+        'last_edited_by': user,
+        'cover': None,
+        'icon': None,
+        'parent': {'type': 'page_id', 'page_id': mock_id()},
+        'archived': False,
+        'properties': {
+            'title': {
+                'id': 'title',
+                'type': 'title',
+                'title': [{
+                    'type': 'text', 'text': {'content': title, 'link': None},
+                    'annotations': {
+                        'bold': False,
+                        'italic': False,
+                        'strikethrough': False,
+                        'underline': False,
+                        'code': False,
+                        'color': 'default'},
+                    'plain_text': title, 'href': None
                 }]
-                }
-                },
-    'url':f'https://www.notion.so/{hyphenated_title}-{notion_id}',
+            }
+        },
+        'url': f'https://www.notion.so/{hyphenated_title}-{notion_id}',
     }
 
     return page_object
-

--- a/n2y/notion_mocks.py
+++ b/n2y/notion_mocks.py
@@ -147,16 +147,11 @@ def mock_relation_value():
 
 
 def mock_page(title="Mock Title"):
-
-    # Returns a mock version the data that would be returned by
-    # the Notion API on a client.get_page() request.
-
     user = mock_user()
     created_time = datetime.now().isoformat()
     notion_id = mock_id()
     hyphenated_title = title.replace(" ", "-")
-
-    page_object = {
+    return {
         'object': 'page',
         'id': notion_id,
         'created_time': created_time,
@@ -171,20 +166,10 @@ def mock_page(title="Mock Title"):
             'title': {
                 'id': 'title',
                 'type': 'title',
-                'title': [{
-                    'type': 'text', 'text': {'content': title, 'link': None},
-                    'annotations': {
-                        'bold': False,
-                        'italic': False,
-                        'strikethrough': False,
-                        'underline': False,
-                        'code': False,
-                        'color': 'default'},
-                    'plain_text': title, 'href': None
-                }]
+                'title': mock_rich_text_array([
+                    (title, []),
+                ]),
             }
         },
         'url': f'https://www.notion.so/{hyphenated_title}-{notion_id}',
     }
-
-    return page_object

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -594,19 +594,13 @@ def test_synced_block_unshared():
 
 
 def test_link_to_page_page():
-    # TODO: implement these tests; use mock.patch to mockout the notion API's
-    # response to the get_database_or_page call inside the default linktopage thing
-    # Also, create a separate `mock_page` and `mock_database` calls to test.
-    # Follow the format of the data in the Notion API docs for these
 
-    notion_id = mock_id()
- 
     mock_link_to_page_block = mock_block(
-        "link_to_page", {"type": "page_id", "page_id": mock_id()} )
-    
+        "link_to_page", {"type": "page_id", "page_id": mock_id()})
+
     page = mock_page("Linked Page")
 
-    with mock.patch("n2y.notion.Client._get_url", return_value = page):
+    with mock.patch("n2y.notion.Client._get_url", return_value=page):
         pandoc_ast, markdown = process_block(mock_link_to_page_block)
 
     assert pandoc_ast == Para([Str("Linked"), Space(), Str("Page")])

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -594,30 +594,14 @@ def test_synced_block_unshared():
 
 
 def test_link_to_page_page():
-
     mock_link_to_page_block = mock_block(
-        "link_to_page", {"type": "page_id", "page_id": mock_id()})
-
+        "link_to_page", {"type": "page_id", "page_id": mock_id()},
+    )
     page = mock_page("Linked Page")
-
     with mock.patch("n2y.notion.Client._get_url", return_value=page):
         pandoc_ast, markdown = process_block(mock_link_to_page_block)
-
     assert pandoc_ast == Para([Str("Linked"), Space(), Str("Page")])
     assert markdown == "Linked Page\n"
-
-
-@pytest.mark.xfail(reason="Not fully implemented")
-def test_link_to_page_database():
-    mock_database_id = mock_id()
-    notion_block = mock_block(
-        "link_to_page", {"type": "database_id", "database_id": mock_database_id}
-    )
-
-    pandoc_ast, markdown = process_block(notion_block)
-
-    assert pandoc_ast == Para([Str("Simple Test Database")])
-    assert markdown == "Simple Test Database\n"
 
 
 def test_column_block():

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -48,6 +48,7 @@ from n2y.notion_mocks import (
     mock_paragraph_block,
     mock_rich_text,
     mock_page_mention,
+    mock_page,
 )
 
 
@@ -592,19 +593,24 @@ def test_synced_block_unshared():
     assert unshared_reference_markdown == ""
 
 
-@pytest.mark.xfail(reason="Not fully implemented")
 def test_link_to_page_page():
     # TODO: implement these tests; use mock.patch to mockout the notion API's
     # response to the get_database_or_page call inside the default linktopage thing
     # Also, create a separate `mock_page` and `mock_database` calls to test.
     # Follow the format of the data in the Notion API docs for these
-    mock_page_id = mock_id()
-    notion_block = mock_block(
-        "link_to_page", {"type": "page_id", "page_id": mock_page_id}
-    )
-    pandoc_ast, markdown = process_block(notion_block)
-    assert pandoc_ast == Para([Str("All Blocks Test Page")])
-    assert markdown == "All Blocks Test Page\n"
+
+    notion_id = mock_id()
+ 
+    mock_link_to_page_block = mock_block(
+        "link_to_page", {"type": "page_id", "page_id": mock_id()} )
+    
+    page = mock_page("Linked Page")
+
+    with mock.patch("n2y.notion.Client._get_url", return_value = page):
+        pandoc_ast, markdown = process_block(mock_link_to_page_block)
+
+    assert pandoc_ast == Para([Str("Linked"), Space(), Str("Page")])
+    assert markdown == "Linked Page\n"
 
 
 @pytest.mark.xfail(reason="Not fully implemented")


### PR DESCRIPTION
New unit test for blocks of type link_to_page.

Such blocks can be of two types: page or database.   As both types of expansions use the same procedure, a "database" version of this unit test would be redundant.

Link to the issue:
https://github.com/innolitics/n2y/issues/66