### PR TITLE
Add pagination for relation properties when there are more than 25

### DIFF
--- a/n2y/notion.py
+++ b/n2y/notion.py
@@ -271,8 +271,14 @@ class Client:
     def wrap_notion_property(self, notion_data):
         return self.instantiate_class("properties", notion_data["type"], self, notion_data)
 
-    def wrap_notion_property_value(self, notion_data):
-        return self.instantiate_class("property_values", notion_data["type"], self, notion_data)
+    def wrap_notion_property_value(self, notion_data, page):
+        return self.instantiate_class(
+            "property_values",
+            notion_data["type"],
+            self,
+            notion_data,
+            page
+        )
 
     def get_page_or_database(self, object_id):
         """

--- a/n2y/page.py
+++ b/n2y/page.py
@@ -25,7 +25,7 @@ class Page:
         self.cover = notion_data['cover'] and client.wrap_notion_file(notion_data['cover'])
         self.archived = notion_data['archived']
         self.properties = {
-            k: client.wrap_notion_property_value(npv)
+            k: client.wrap_notion_property_value(npv, self)
             for k, npv in notion_data['properties'].items()
         }
         self.notion_parent = notion_data['parent']

--- a/n2y/property_values.py
+++ b/n2y/property_values.py
@@ -8,21 +8,22 @@ logger = logging.getLogger(__name__)
 
 
 class PropertyValue:
-    def __init__(self, client, notion_data):
+    def __init__(self, client, notion_data, page):
         self.client = client
         self.notion_property_id = notion_data.get(
             'id', None)  # will be none for rollup array values
         self.notion_type = notion_data['type']
+        self.page = page
 
     def to_value(self):
         raise NotImplementedError()
 
 
 class TitlePropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
+    def __init__(self, client, notion_data, page):
         # TODO: handle the case when there are more than 25 rich text items in the property
         # See https://developers.notion.com/reference/retrieve-a-page-property
-        super().__init__(client, notion_data)
+        super().__init__(client, notion_data, page)
         self.rich_text = client.wrap_notion_rich_text_array(notion_data['title'])
 
     def to_value(self):
@@ -35,10 +36,10 @@ class TitlePropertyValue(PropertyValue):
 
 
 class TextPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
+    def __init__(self, client, notion_data, page):
         # TODO: handle the case when there are more than 25 rich text items in the property
         # See https://developers.notion.com/reference/retrieve-a-page-property
-        super().__init__(client, notion_data)
+        super().__init__(client, notion_data, page)
         self.rich_text = client.wrap_notion_rich_text_array(notion_data['rich_text'])
 
     def to_value(self):
@@ -46,8 +47,8 @@ class TextPropertyValue(PropertyValue):
 
 
 class NumberPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.number = notion_data['number']
 
     def to_value(self):
@@ -55,8 +56,8 @@ class NumberPropertyValue(PropertyValue):
 
 
 class SelectPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         notion_select = notion_data['select']
         if notion_select is not None:
             self.notion_option_id = notion_select['id']
@@ -74,8 +75,8 @@ class SelectPropertyValue(PropertyValue):
 
 
 class MultiSelectPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.options = [MultiSelectOption(self.client, no) for no in notion_data['multi_select']]
 
     def to_value(self):
@@ -93,9 +94,9 @@ class MultiSelectOption:
 
 
 class DatePropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
+    def __init__(self, client, notion_data, page):
         # TODO: handle timezones
-        super().__init__(client, notion_data)
+        super().__init__(client, notion_data, page)
         self.value = process_notion_date(notion_data['date'])
 
     def to_value(self):
@@ -106,8 +107,8 @@ class DatePropertyValue(PropertyValue):
 
 
 class PeoplePropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.people = [client.wrap_notion_user(nu) for nu in notion_data['people']]
 
     def to_value(self):
@@ -115,8 +116,8 @@ class PeoplePropertyValue(PropertyValue):
 
 
 class FilesPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.files = [client.wrap_notion_file(nf) for nf in notion_data['files']]
 
     def to_value(self):
@@ -124,8 +125,8 @@ class FilesPropertyValue(PropertyValue):
 
 
 class CheckboxPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.checkbox = notion_data['checkbox']
 
     def to_value(self):
@@ -133,8 +134,8 @@ class CheckboxPropertyValue(PropertyValue):
 
 
 class UrlPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.url = notion_data['url']
 
     def to_value(self):
@@ -142,8 +143,8 @@ class UrlPropertyValue(PropertyValue):
 
 
 class EmailPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.email = notion_data['email']
 
     def to_value(self):
@@ -151,8 +152,8 @@ class EmailPropertyValue(PropertyValue):
 
 
 class PhoneNumberPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.phone_number = notion_data['phone_number']
 
     def to_value(self):
@@ -160,8 +161,8 @@ class PhoneNumberPropertyValue(PropertyValue):
 
 
 class FormulaPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         # TODO: set other attributes
         notion_formula = notion_data["formula"]
         if notion_formula["type"] == "date":
@@ -174,10 +175,10 @@ class FormulaPropertyValue(PropertyValue):
 
 
 class RelationPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
+    def __init__(self, client, notion_data, page):
         # TODO: handle the case when there are more than 25 pages in the relation
         # See https://developers.notion.com/reference/retrieve-a-page-property
-        super().__init__(client, notion_data)
+        super().__init__(client, notion_data, page)
         self.ids = [related["id"] for related in notion_data["relation"]]
 
     def to_value(self):
@@ -185,10 +186,10 @@ class RelationPropertyValue(PropertyValue):
 
 
 class RollupPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
+    def __init__(self, client, notion_data, page):
         # TODO: handle the case when the rollup needs to be paginated
         # See https://developers.notion.com/reference/retrieve-a-page-property
-        super().__init__(client, notion_data)
+        super().__init__(client, notion_data, page)
         notion_rollup = notion_data["rollup"]
         self.rollup_type = notion_rollup["type"]
         self.function = notion_rollup["function"]
@@ -200,7 +201,7 @@ class RollupPropertyValue(PropertyValue):
             self.value = notion_rollup['number']
         elif self.rollup_type == "array":
             self.value = [
-                self.client.wrap_notion_property_value(pv)
+                self.client.wrap_notion_property_value(pv, page)
                 for pv in notion_rollup['array']
             ]
         else:
@@ -222,8 +223,8 @@ class RollupPropertyValue(PropertyValue):
 
 
 class CreatedTimePropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.created_time = fromisoformat(notion_data['created_time'])
 
     def to_value(self):
@@ -231,8 +232,8 @@ class CreatedTimePropertyValue(PropertyValue):
 
 
 class CreatedByPropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.created_by = client.wrap_notion_user(notion_data['created_by'])
 
     def to_value(self):
@@ -240,8 +241,8 @@ class CreatedByPropertyValue(PropertyValue):
 
 
 class LastEditedTimePropertyValue(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.last_edited_time = fromisoformat(notion_data['last_edited_time'])
 
     def to_value(self):
@@ -249,8 +250,8 @@ class LastEditedTimePropertyValue(PropertyValue):
 
 
 class LastEditedBy(PropertyValue):
-    def __init__(self, client, notion_data):
-        super().__init__(client, notion_data)
+    def __init__(self, client, notion_data, page):
+        super().__init__(client, notion_data, page)
         self.last_edited_by = client.wrap_notion_user(notion_data['last_edited_by'])
 
     def to_value(self):

--- a/n2y/property_values.py
+++ b/n2y/property_values.py
@@ -176,10 +176,15 @@ class FormulaPropertyValue(PropertyValue):
 
 class RelationPropertyValue(PropertyValue):
     def __init__(self, client, notion_data, page):
-        # TODO: handle the case when there are more than 25 pages in the relation
-        # See https://developers.notion.com/reference/retrieve-a-page-property
         super().__init__(client, notion_data, page)
-        self.ids = [related["id"] for related in notion_data["relation"]]
+        if "has_more" not in notion_data or not notion_data["has_more"]:
+            self.ids = [related["id"] for related in notion_data["relation"]]
+        else:
+            url = f"{client.base_url}pages/{page.notion_id}/properties/{self.notion_property_id}"
+            self.ids = [
+                r["relation"]["id"] for r in
+                client._paginated_request(client._get_url, url, {})
+            ]
 
     def to_value(self):
         return self.ids

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -312,3 +312,13 @@ def test_comment():
     comments = Client(NOTION_ACCESS_TOKEN).get_comments(block_with_comments_id)
     assert comments[0].rich_text.to_plain_text() == "Test Comment"
     assert comments[1].rich_text.to_plain_text() == "Test Comment 2"
+
+
+def test_can_pull_all_relations(tmpdir):
+    object_id = "e611d7fdd4604d1192637a25bc9f5339"
+    page = run_n2y_page(tmpdir, object_id)
+    uuids = re.findall(
+        '[^\"][0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}[^\"]',
+        page
+    )
+    assert len(uuids) == 31

--- a/tests/test_property_values.py
+++ b/tests/test_property_values.py
@@ -2,7 +2,7 @@ import pytest
 from n2y import notion
 
 from n2y.notion_mocks import (
-    mock_formula_property_value, mock_person_user,
+    mock_formula_property_value, mock_person_user, mock_relation_value,
     mock_rich_text, mock_property_value, mock_rich_text_array,
     mock_rollup_property_value, mock_select_option, mock_user,
 )
@@ -151,6 +151,24 @@ def test_formula_date_empty():
 def test_formula_date_start_only():
     notion_data = mock_formula_property_value('date', {'start': '2022-05-11'})
     assert process_property_value(notion_data) == '2022-05-11'
+
+
+def test_relationship_empty():
+    notion_data = mock_property_value('relation', [])
+    assert process_property_value(notion_data) == []
+
+
+def test_relationship_single():
+    item = mock_relation_value()
+    notion_data = mock_property_value('relation', [item])
+    assert process_property_value(notion_data) == [item["id"]]
+
+
+def test_relationship_double():
+    item1 = mock_relation_value()
+    item2 = mock_relation_value()
+    notion_data = mock_property_value('relation', [item1, item2])
+    assert process_property_value(notion_data) == [item1["id"], item2["id"]]
 
 
 def test_rollup_date_empty():

--- a/tests/test_property_values.py
+++ b/tests/test_property_values.py
@@ -2,7 +2,7 @@ import pytest
 from n2y import notion
 
 from n2y.notion_mocks import (
-    mock_formula_property_value, mock_person_user, mock_relation_value,
+    mock_formula_property_value, mock_person_user,
     mock_rich_text, mock_property_value, mock_rich_text_array,
     mock_rollup_property_value, mock_select_option, mock_user,
 )
@@ -10,7 +10,7 @@ from n2y.notion_mocks import (
 
 def process_property_value(notion_data):
     client = notion.Client('')
-    property_value = client.wrap_notion_property_value(notion_data)
+    property_value = client.wrap_notion_property_value(notion_data, None)
     return property_value.to_value()
 
 
@@ -151,24 +151,6 @@ def test_formula_date_empty():
 def test_formula_date_start_only():
     notion_data = mock_formula_property_value('date', {'start': '2022-05-11'})
     assert process_property_value(notion_data) == '2022-05-11'
-
-
-def test_relationship_empty():
-    notion_data = mock_property_value('relation', [])
-    assert process_property_value(notion_data) == []
-
-
-def test_relationship_single():
-    item = mock_relation_value()
-    notion_data = mock_property_value('relation', [item])
-    assert process_property_value(notion_data) == [item["id"]]
-
-
-def test_relationship_double():
-    item1 = mock_relation_value()
-    item2 = mock_relation_value()
-    notion_data = mock_property_value('relation', [item1, item2])
-    assert process_property_value(notion_data) == [item1["id"], item2["id"]]
 
 
 def test_rollup_date_empty():


### PR DESCRIPTION
We were not pulling all property relationships when there were more than 25. This is what was causing missing data. I added pagination for relation property values so now we should get all of them.

# Author's Checklist

Before assigning reviewers, step through the following checklist. Check each item once it's completed. If an item is skipped, write an explanation below the item.

- [X] **Construction:** Review the code diff and confirm there's no dead code, debug code, or unnecessary comments.
- [X] **Requirements:** Review the requirements in the issue for this PR and confirm they're all implemented.
- [X] **Architecture:** Confirm that the changes to the code are consistent with the existing architecture.
- [X] **SOUP/OTS Software:** Any new dependencies have appropriate licenses and are documented or pinned in requirements files.
- [X] **Unit Test:** Atomic unit tests have been added, if appropriate.
- [X] **End-to-End Tests:** End-to-end tests have been extended or updated, if appropriate.
- [X] **Low-level Documentation:** Comments or doc strings for affected code have been updated.
- [X] **High-Level Documentation:** The README is updated, as appropriate.
- [X] **Change Log:** New features or bug fixes have been added to the change log in the README.
