### PR TITLE
New footnote plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Most of the Notion blocks can generate their pandoc AST from _only_ their own da
 
 ## Built-in Plugins
 
-N2y provides a few builtin plugins. These plugins are all turned off by default. Brief descriptions are provided below, but see [the code](https://github.com/innolitics/n2y/tree/rich-text-extensions/n2y/plugins) for details.
+N2y provides a few builtin plugins. These plugins are all turned off by default. Brief descriptions are provided below, but see [the code](https://github.com/innolitics/n2y/tree/main/n2y/plugins) for details.
 
 ### Render
 
@@ -274,6 +274,9 @@ Replace headers with links back to the originating notion block.
 ### Footnotes
 
 Adds support for Pandoc-style footnotes. Any `text` rich texts that contain footnote references in the format `[^NUMBER]` (eg: `...some claim [^2].`) will be linked to the corresponding footnote paragraph block starting with `[NUMBER]:` (eg: `[2]: This is a footnote.`).
+
+### DB Footnotes
+Adds general footnote support (not specialized for markdown) with the expectation that all footnote content is placed in an inline database on the original page wherein footnote references are made. Specific footnote references are made with Notion's page mention feature, mentioning a specific footnote page in the database. For example, each page in the database can simply be titled with a footnote number and contain the footnote text as the page content. The inline database must have a title that ends with "Footnotes."
 
 ### Expand Link To Page Blocks
 

--- a/n2y/plugins/dbfootnotes.py
+++ b/n2y/plugins/dbfootnotes.py
@@ -14,17 +14,26 @@ logger = logging.getLogger(__name__)
 class PageMentionFootnote(PageMention):
     def __init__(self, client, notion_data, plain_text, block=None):
         super().__init__(client, notion_data, plain_text, block)
-        self.mentioned_page = self.client.get_page(self.notion_page_id)
-        if self._is_footnote():
+        if (
+            self._get_mention_page()
+            and self._get_mention_page_parent()
+            and self._is_footnote()
+        ):
             self._attach_footnote()
         else:
             raise UseNextClass
 
+    def _get_mention_page(self):
+        self.mentioned_page = self.client.get_page(self.notion_page_id)
+        return self.mentioned_page is not None
+
+    def _get_mention_page_parent(self):
+        self.mentioned_page_parent = self.mentioned_page.parent
+        return self.mentioned_page_parent is not None
+
     def _is_footnote(self):
-        if self.mentioned_page is not None and isinstance(
-            self.mentioned_page.parent, Database
-        ):
-            return self.mentioned_page.parent.title.to_plain_text().endswith(
+        if isinstance(self.mentioned_page_parent, Database):
+            return self.mentioned_page_parent.title.to_plain_text().endswith(
                 "Footnotes"
             )
         else:

--- a/n2y/plugins/dbfootnotes.py
+++ b/n2y/plugins/dbfootnotes.py
@@ -14,20 +14,16 @@ logger = logging.getLogger(__name__)
 class PageMentionFootnote(PageMention):
     def __init__(self, client, notion_data, plain_text, block=None):
         super().__init__(client, notion_data, plain_text, block)
-        if (
-            self._get_mention_page()
-            and self._get_mention_page_parent()
-            and self._is_footnote()
-        ):
+        if self._get_mention() and self._get_parent() and self._is_footnote():
             self._attach_footnote()
         else:
             raise UseNextClass
 
-    def _get_mention_page(self):
+    def _get_mention(self):
         self.mentioned_page = self.client.get_page(self.notion_page_id)
         return self.mentioned_page is not None
 
-    def _get_mention_page_parent(self):
+    def _get_parent(self):
         self.mentioned_page_parent = self.mentioned_page.parent
         return self.mentioned_page_parent is not None
 

--- a/n2y/plugins/dbfootnotes.py
+++ b/n2y/plugins/dbfootnotes.py
@@ -1,0 +1,45 @@
+import logging
+
+from pandoc.types import Note
+
+from n2y.database import Database
+from n2y.errors import UseNextClass
+from n2y.mentions import PageMention
+
+plugin_data_key = "n2y.plugins.dbfootnotes"
+
+logger = logging.getLogger(__name__)
+
+
+class PageMentionFootnote(PageMention):
+    def __init__(self, client, notion_data, plain_text, block=None):
+        super().__init__(client, notion_data, plain_text, block)
+        self.mentioned_page = self.client.get_page(self.notion_page_id)
+        if self._is_footnote():
+            self._attach_footnote()
+        else:
+            raise UseNextClass
+
+    def _is_footnote(self):
+        if self.mentioned_page is not None and isinstance(
+            self.mentioned_page.parent, Database
+        ):
+            return self.mentioned_page.parent.title.to_plain_text().endswith(
+                "Footnotes"
+            )
+        else:
+            return False
+
+    def _attach_footnote(self):
+        block_content = self.mentioned_page.block.children_to_pandoc()
+        self._footnote_in_pandoc_ast = (
+            Note(block_content)
+            if isinstance(block_content, list)
+            else Note([block_content])
+        )
+
+    def to_pandoc(self):
+        return [self._footnote_in_pandoc_ast]
+
+
+notion_classes = {"mentions": {"page": PageMentionFootnote}}

--- a/n2y/plugins/dbfootnotes.py
+++ b/n2y/plugins/dbfootnotes.py
@@ -3,7 +3,7 @@ import logging
 from pandoc.types import Note
 
 from n2y.database import Database
-from n2y.errors import UseNextClass
+from n2y.errors import PluginError, UseNextClass
 from n2y.mentions import PageMention
 
 plugin_data_key = "n2y.plugins.dbfootnotes"
@@ -12,26 +12,60 @@ logger = logging.getLogger(__name__)
 
 
 class PageMentionFootnote(PageMention):
-    def __init__(self, client, notion_data, plain_text, block=None):
+    def __init__(self, client, notion_data, plain_text, block):
         super().__init__(client, notion_data, plain_text, block)
-        if self._get_mention() and self._get_parent() and self._is_footnote():
+        if block is not None and self._references_correct() and self._is_footnote():
             self._attach_footnote()
         else:
             raise UseNextClass
 
     def _get_mention(self):
+        # This should be the footnote content page.
         self.mentioned_page = self.client.get_page(self.notion_page_id)
         return self.mentioned_page is not None
 
-    def _get_parent(self):
+    def _get_parents(self):
+        # This should be the inline database.
         self.mentioned_page_parent = self.mentioned_page.parent
-        return self.mentioned_page_parent is not None
+        # This should be the same page that houses the original mention.
+        self.mentioned_page_parent_parent = self.mentioned_page_parent.parent
+        return (
+            self.mentioned_page_parent is not None
+            and self.mentioned_page_parent_parent is not None
+        )
+
+    def _references_correct(self):
+        return self._get_mention() is not None and self._get_parents() is not None
 
     def _is_footnote(self):
-        if isinstance(self.mentioned_page_parent, Database):
-            return self.mentioned_page_parent.title.to_plain_text().endswith(
-                "Footnotes"
-            )
+        # Check that the footnote parent is a DB with the "Footnotes" suffix in the title.
+        if isinstance(
+            self.mentioned_page_parent, Database
+        ) and self.mentioned_page_parent.title.to_plain_text().endswith("Footnotes"):
+            # Raise an exception if the footnotes DB is not a child of the original page.
+            # I.e., it's a valid Footnotes DB but not a child (inline) with the original page.
+            # This could occur if the user referenced a Footnotes DB on a different page, which
+            # we explicitly do not support.
+            if (
+                not self.mentioned_page_parent_parent.notion_data["id"]
+                == self.block.page.notion_data["id"]
+            ):
+                try:
+                    footnote_identifier = (
+                        f"title: {self.mentioned_page.title.to_plain_text()}"
+                    )
+                except AttributeError:
+                    footnote_identifier = f"id: {self.mentioned_page.notion_data['id']}"
+
+                raise PluginError(
+                    f"Using plugin `{plugin_data_key}`: "
+                    f"For footnote ({footnote_identifier}) mention "
+                    f"on page: {self.block.page.notion_data['url']}, "
+                    "the associated footnotes DB "
+                    f"({self.mentioned_page_parent.notion_data['url']}) "
+                    "is not a child of the original page"
+                )
+            return True
         else:
             return False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal=1
 
 [flake8]
-ignore = E226,E731,E741
+ignore = E226,E731,E741,W503,W504
 exclude = .tox,*.egg,build,data,venv
 select = E,W,F
 max-line-length = 100

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -388,7 +388,7 @@ def test_dbfootnote_plugin(tmpdir):
     """
     This test exercises our database footnote. It involves a simple page with
     an inline database containing content for 3 footnotes.
-    
+
     The page can be seen here:
     https://www.notion.so/Advanced-DB-Footnote-8a1a17c7ef3043f4bd9fb041ef31ba7
     """

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -382,3 +382,24 @@ def test_jinja_render_plugin(tmpdir):
     assert "## pink is a color" in document
     assert "## red is a color" in document
     assert "Page with JinjaCodeBlock" in document
+
+
+def test_dbfootnote_plugin(tmpdir):
+    """
+    This test exercises our database footnote. It involves a simple page with
+    an inline database containing content for 3 footnotes.
+    
+    The page can be seen here:
+    https://www.notion.so/Advanced-DB-Footnote-8a1a17c7ef3043f4bd9fb041ef31ba7
+    """
+    object_id = "8a1a17c7ef3043f4bd9fb041ef31ba7d"
+    document = run_n2y_page(tmpdir, object_id, plugins=[
+        "n2y.plugins.dbfootnotes",
+    ])
+
+    assert "some text [^1]." in document
+    assert "like so [^2] and" in document
+    assert "so [^3]." in document
+    assert "[^1]: Inline DB content for footnote 1." in document
+    assert "[^2]: Inline DB content for footnote 2." in document
+    assert "[^3]: Inline DB content for footnote 3." in document

--- a/tests/test_plugin_dbfootnotes.py
+++ b/tests/test_plugin_dbfootnotes.py
@@ -1,33 +1,77 @@
+import pytest
+
+from n2y.blocks import ParagraphBlock
 from n2y.database import Database
+from n2y.errors import PluginError
 from n2y.mentions import PageMention
 from n2y.notion import Client
-from n2y.notion_mocks import mock_database, mock_page, mock_page_mention
+from n2y.notion_mocks import (
+    mock_database,
+    mock_page,
+    mock_page_mention,
+    mock_paragraph_block,
+)
 from n2y.page import Page
 from n2y.plugins.dbfootnotes import PageMentionFootnote
 
 
-def mock_page_mention_with_footnote(parent):
+def mock_page_mention_with_footnote(
+    mentioned_page_parent, connect_parent_correctly=True
+):
     client = Client("", plugins=["n2y.plugins.dbfootnotes"])
+    # The original page, with the footnote ref.
+    original_page = mock_page()
+    # A paragraph in the original page where the mention occurs.
+    paragraph_with_footnote_ref = mock_paragraph_block("Text with footnote ref")
+    # The mention itself.
     mentioned_page = mock_page()
-    mentioned_page_parent = parent
     mention = mock_page_mention()
     mention_text = "1"
+    # Connect all of these mocked pages per the expected scenario.
     mention["page"]["id"] = mentioned_page["id"]
+    # The parent of the mentioned page should be the inline DB.
     mentioned_page["parent"] = {
         "type": "page_id",
         "page_id": mentioned_page_parent["id"],
     }
+    # The parent of the block with the mention should be the original page.
+    paragraph_with_footnote_ref["parent"] = {
+        "type": "page_id",
+        "page_id": original_page["id"],
+    }
+    # In the correct scenario, the parent of the mentioned page's parent should
+    # be the original page (the case of an inline DB).
+    if connect_parent_correctly:
+        mentioned_page_parent["parent"] = {
+            "type": "page_id",
+            "page_id": original_page["id"],
+        }
+        mentioned_page_parent_parent_n2y = Page(client, original_page)
+    else:
+        not_original_page = mock_page()
+        mentioned_page_parent["parent"] = {
+            "type": "page_id",
+            "page_id": not_original_page["id"],
+        }
+        mentioned_page_parent_parent_n2y = Page(client, not_original_page)
 
+    # Create `n2y` types from raw data constructed thus far.
+    original_page_n2y = Page(client, original_page)
     mentioned_page_n2y = Page(client, mentioned_page)
-    if parent["object"] == "database":
+    if mentioned_page_parent["object"] == "database":
         mentioned_page_parent_n2y = Database(client, mentioned_page_parent)
     else:
         mentioned_page_parent_n2y = Page(client, mentioned_page_parent)
+    block = ParagraphBlock(client, paragraph_with_footnote_ref, original_page_n2y)
 
     page_mention_footnote_n2y = PageMentionFootnote.__new__(PageMentionFootnote)
     PageMention.__init__(page_mention_footnote_n2y, client, mention, mention_text)
     page_mention_footnote_n2y.mentioned_page = mentioned_page_n2y
+    page_mention_footnote_n2y.block = block
     page_mention_footnote_n2y.mentioned_page_parent = mentioned_page_parent_n2y
+    page_mention_footnote_n2y.mentioned_page_parent_parent = (
+        mentioned_page_parent_parent_n2y
+    )
 
     return page_mention_footnote_n2y
 
@@ -40,6 +84,21 @@ def test_check_that_mention_parent_is_a_database():
 
     assert from_page_mention_with_page_parent._is_footnote() is False
     assert from_page_mention_with_db_parent._is_footnote() is True
+
+
+def test_check_that_mention_parent_is_inline_db_of_original_page():
+    from_page_mention_with_inline_db = mock_page_mention_with_footnote(
+        mentioned_page_parent=mock_database("Footnotes"),
+        connect_parent_correctly=True,
+    )
+
+    assert from_page_mention_with_inline_db._is_footnote() is True
+
+    with pytest.raises(PluginError):
+        mock_page_mention_with_footnote(
+            mentioned_page_parent=mock_database("Footnotes"),
+            connect_parent_correctly=False,
+        )._is_footnote()
 
 
 def test_footnote_db_naming_convention():

--- a/tests/test_plugin_dbfootnotes.py
+++ b/tests/test_plugin_dbfootnotes.py
@@ -1,0 +1,62 @@
+from n2y.database import Database
+from n2y.mentions import PageMention
+from n2y.notion import Client
+from n2y.notion_mocks import mock_database, mock_page, mock_page_mention
+from n2y.page import Page
+from n2y.plugins.dbfootnotes import PageMentionFootnote
+
+
+def mock_page_mention_with_footnote(parent):
+    client = Client("", plugins=["n2y.plugins.dbfootnotes"])
+    mentioned_page = mock_page()
+    mentioned_page_parent = parent
+    mention = mock_page_mention()
+    mention_text = "1"
+    mention["page"]["id"] = mentioned_page["id"]
+    mentioned_page["parent"] = {
+        "type": "page_id",
+        "page_id": mentioned_page_parent["id"],
+    }
+
+    mentioned_page_n2y = Page(client, mentioned_page)
+    if parent["object"] == "database":
+        mentioned_page_parent_n2y = Database(client, mentioned_page_parent)
+    else:
+        mentioned_page_parent_n2y = Page(client, mentioned_page_parent)
+
+    page_mention_footnote_n2y = PageMentionFootnote.__new__(PageMentionFootnote)
+    PageMention.__init__(page_mention_footnote_n2y, client, mention, mention_text)
+    page_mention_footnote_n2y.mentioned_page = mentioned_page_n2y
+    page_mention_footnote_n2y.mentioned_page_parent = mentioned_page_parent_n2y
+
+    return page_mention_footnote_n2y
+
+
+def test_check_that_mention_parent_is_a_database():
+    from_page_mention_with_page_parent = mock_page_mention_with_footnote(mock_page())
+    from_page_mention_with_db_parent = mock_page_mention_with_footnote(
+        mock_database("Footnotes")
+    )
+
+    assert from_page_mention_with_page_parent._is_footnote() is False
+    assert from_page_mention_with_db_parent._is_footnote() is True
+
+
+def test_footnote_db_naming_convention():
+    page_mention_prefix = mock_page_mention_with_footnote(
+        mock_database("Prefix Footnotes")
+    )
+    page_mention_suffix = mock_page_mention_with_footnote(
+        mock_database("Footnotes Suffix")
+    )
+    page_mention_case_issue = mock_page_mention_with_footnote(
+        mock_database("My footnotes")
+    )
+    page_mention_plural_issue = mock_page_mention_with_footnote(
+        mock_database("My Footnote")
+    )
+
+    assert page_mention_prefix._is_footnote() is True
+    assert page_mention_suffix._is_footnote() is False
+    assert page_mention_case_issue._is_footnote() is False
+    assert page_mention_plural_issue._is_footnote() is False


### PR DESCRIPTION
Added new `dbfootnotes` plugin. Major features:
- Supports footnotes as page mentions where each footnote is a page in a footnotes database (and which will typically be an inline database).
- To be promoted to a footnote, a page mention must come from a database with a title ending with "Footnotes".
- Confirmed footnotes are implemented with the `Note` type in the Pandoc AST for general export (i.e., not specialized for markdown only).

# Author's Checklist

Before assigning reviewers, step through the following checklist. Check each item once it's completed. If an item is skipped, write an explanation below the item.

- [x] **Construction:** Review the code diff and confirm there's no dead code, debug code, or unnecessary comments.
- [x] **Requirements:** Review the requirements in the issue for this PR and confirm they're all implemented.
- [x] **Architecture:** Confirm that the changes to the code are consistent with the existing architecture.
- [x] **SOUP/OTS Software:** Any new dependencies have appropriate licenses and are documented or pinned in requirements files.
- [x] **Unit Test:** Atomic unit tests have been added, if appropriate.
- [x] **End-to-End Tests:** End-to-end tests have been extended or updated, if appropriate.
- [x] **Low-level Documentation:** Comments or doc strings for affected code have been updated.
- [x] **High-Level Documentation:** The README is updated, as appropriate.
- [x] **Change Log:** New features or bug fixes have been added to the change log in the README.
