### PR TITLE
update mermaid plugin to use figure flag

### DIFF
--- a/n2y/plugins/mermaid.py
+++ b/n2y/plugins/mermaid.py
@@ -70,7 +70,12 @@ class MermaidFencedCodeBlock(FencedCodeBlock):
                             'Syntax Error In Graph'
                         )
                 url = self.client.save_file(content, self.page, '.png', self.notion_id)
-            return Para([Image(('', [], []), self.caption.to_pandoc(), (url, ''))])
+                caption = []
+                fig_flag = ''
+                if self.caption:
+                    fig_flag = 'fig:'
+                    caption = self.caption.to_pandoc()
+            return Para([Image(('', [], []), caption, (url, fig_flag))])
         except subprocess.CalledProcessError as exc:
             # as of now, mmdc does not ever return a non-zero error code, so
             # this won't ever be hit


### PR DESCRIPTION
# Describe Your Changes
I missed the Image block used in the mermaid plugin so I've now updated it.

# How Did You Test It
I tested it using the `test_numbered_blocks_have_incremental_figure_prefixes` test in notion_qms's test_plugins.py module