### PR TITLE
ignore casing of terms matched by the fuzzy_find_in jinja filter

### DIFF
--- a/n2y/plugins/jinjarenderpage.py
+++ b/n2y/plugins/jinjarenderpage.py
@@ -111,7 +111,7 @@ def join_to(foreign_keys, table, primary_key='notion_id'):
 def list_matches(string, text):
     return list(re.finditer(
         '(?<![a-zA-Z])' + re.escape(_canonicalize(string)) + '(?:s|es)?(?![a-zA-Z])',
-        _canonicalize(text))
+        _canonicalize(text), re.IGNORECASE)
     )
 
 


### PR DESCRIPTION
# Describe Your Changes
Modified the `re.finditr` call to `re.IGNORECASE`  so that lower cased references to the key terms still get matched

# How Did You Test It
I exported SW-0010_MIC_Finder_SDDS_Rev_C from Specific-Dx and ensured that Software Item was included in the glossary, as it's referenced in the document, although in lowercase. I ran the debugger on my n2y code to see if the terms were coming through correctly and they were so that indicated to me that the matching system was filtering out the desired terms. I immediately knew it was the casing so I added the aforementioned flag and that fixed the issue

<img width="579" alt="Screen Shot 2023-08-08 at 3 03 19 PM" src="https://github.com/innolitics/n2y/assets/100145229/2b7994f3-a410-49d8-8ea2-ef7268fe7d54">
<img width="534" alt="Screen Shot 2023-08-08 at 3 01 13 PM" src="https://github.com/innolitics/n2y/assets/100145229/636c16c2-4033-47c8-8448-f767e7538fb8">
