### PR TITLE
Collect Jinja template error info

### DIFF
--- a/n2y/export.py
+++ b/n2y/export.py
@@ -50,7 +50,7 @@ def _page_properties(
         else:
             msg = "Property %s not found in page %s; skipping remapping from %s to %s"
             logger.warning(msg, original, page.notion_url, original, new)
-    return dict(properties)
+    return properties
 
 
 def export_page(

--- a/n2y/page.py
+++ b/n2y/page.py
@@ -4,11 +4,6 @@ from n2y.property_values import TitlePropertyValue
 from n2y.blocks import ChildDatabaseBlock, ChildPageBlock, TableOfContentsBlock
 
 
-class PageProperties(dict):
-    def __dict__(self):
-        return dict(self)
-
-
 class Page:
     def __init__(self, client, notion_data):
         logger.debug("Instantiating page")
@@ -123,4 +118,4 @@ class Page:
         return ast if ignore_toc else self.generate_toc(ast)
 
     def properties_to_values(self, pandoc_format=None):
-        return PageProperties({k: v.to_value(pandoc_format) for k, v in self.properties.items()})
+        return {k: v.to_value(pandoc_format) for k, v in self.properties.items()}

--- a/n2y/utils.py
+++ b/n2y/utils.py
@@ -255,11 +255,11 @@ def stringify_list(array, wrap_in_quotes=False):
 
 def available_from_list(collection, singular, plural):
     if len(collection) == 0:
-        return f'There are no available {plural}'
+        return f'there are no available {plural}'
     elif len(collection) == 1:
-        return f'The only available {singular} is "{collection[0]}"'
+        return f'the only available {singular} is "{collection[0]}"'
     else:
-        return f'The available {plural} are {stringify_list(collection, wrap_in_quotes=True)}'
+        return f'the available {plural} are {stringify_list(collection, wrap_in_quotes=True)}'
 
 
 def load_yaml(data):

--- a/tests/test_jinjarenderpage.py
+++ b/tests/test_jinjarenderpage.py
@@ -175,7 +175,7 @@ def test_jinja_render_with_missing_database():
 
     markdown = pandoc_ast_to_markdown(pandoc_ast)
     assert 'You attempted to access the "MISSING" database.' in markdown
-    assert 'The only available database is "My DB".' in markdown
+    assert 'the only available database is "My DB".' in markdown
 
 
 def test_jinja_render_with_missing_page_property():
@@ -198,7 +198,7 @@ def test_jinja_render_with_missing_page_property():
 
     markdown = pandoc_ast_to_markdown(pandoc_ast)
     assert 'You attempted to access the "MISSING" page property.' in markdown
-    assert 'The only available property is "title".' in markdown
+    assert 'the only available property is "title".' in markdown
 
 
 def test_jinja_render_plain():


### PR DESCRIPTION
# Describe Your Changes
- Add methods of caching error information
    - Create the `JinjaCacheObject` class, which saves error info to the `JinjaFencedCodeBlock`
    - Create the `JinjaDatabaseItem` class, which inherits from the `JinjaCacheObject` class
    - Modify the existing `JinjaDatabaseCache` to inherit from the `JinjaCacheObject` class and instantiate all database child pages as a `JinjaDatabaseItem`
    - Modify the existing `PageProperties` class to inherit from the `JinjaCacheObject` class
    - Add a method to the `JinjaFencedCodeBlock` class that wraps all built-in Jinja filters and tests to save error info

# How Did You Test It
These changes don't change any functionalities yet, so no tests need to be written or modified.