### PR TITLE
add handle for index errors during table of contents creation

### DIFF
--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -269,10 +269,11 @@ class TableOfContentsItemBlock(NumberedListItemBlock, TableOfContentsBlock):
                     subsections[index].append(header)
                 except IndexError:
                     logger.warning((
-                        f'Skipping out-of-order header "{header[1][0]}" in table of contents for page named '
-                        f'{self.page.title.to_plain_text()} ({self.page.notion_url}). Please create headers in '
-                        f'sequence (i.e. proper document formatting dictates that an H{self.level} should '
-                        f'not be immediately followed by an H{header[0]}, but an H{self.level + 1}).'
+                        f'Skipping out-of-order header "{header[1][0]}" in table of contents for '
+                        f'page named {self.page.title.to_plain_text()} ({self.page.notion_url}). '
+                        f'Please create headers in sequence (i.e. proper document formatting '
+                        f'dictates that an H{self.level} should not be immediately followed by an '
+                        f'H{header[0]}, but an H{self.level + 1}).'
                     ))
         for subsection in subsections:
             notion_data = self.generate_item_block(subsection)

--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -265,7 +265,15 @@ class TableOfContentsItemBlock(NumberedListItemBlock, TableOfContentsBlock):
                 index += 1
                 subsections.append([header])
             if header[0] > self.level + 1:
-                subsections[index].append(header)
+                try:
+                    subsections[index].append(header)
+                except IndexError:
+                    logger.warning((
+                        f'Skipping out-of-order header "{header[1][0]}" in table of contents for page named '
+                        f'{self.page.title.to_plain_text()} ({self.page.notion_url}). Please create headers in '
+                        f'sequence (i.e. proper document formatting dictates that an H{self.level} should '
+                        f'not be immediately followed by an H{header[0]}, but an H{self.level + 1}).'
+                    ))
         for subsection in subsections:
             notion_data = self.generate_item_block(subsection)
             children.append(TableOfContentsItemBlock(self.client, notion_data, self.page))


### PR DESCRIPTION
# Describe Your Changes
Add exception handling for Index Errors during TOC creation. I elected to skip and warn users about unordered headers because I didn't want to just write a hacky way to try to handle them or throw an error for the sake of workflow.

# How Did You Test It
I exported [DOC-0013 User Manual](https://www.notion.so/DOC-0013-User-Manual-d5a66abddf8749479c5c3bb0c7106235?pvs=4) in the BodyCheck workspace, as exporting it is how I found this exception. In it, they have an H1 followed by an H3. Figure 1 shows the error I was initially receiving and Figure 2 shows how this addition will log the corresponding warning.

## Figure 1
<img width="1440" alt="Screen Shot 2023-09-11 at 11 56 14 AM" src="https://github.com/innolitics/n2y/assets/100145229/53a0b3e4-65e9-4c59-9a45-40d16905a8f6">

## Figure 2
<img width="1440" alt="Screen Shot 2023-09-11 at 12 19 34 PM" src="https://github.com/innolitics/n2y/assets/100145229/16fc1a5a-63f3-4524-9ad8-3a64ace121ee">


