### PR TITLE
make error handling only dependant on block-specific variables

### DIFF
--- a/n2y/plugins/jinjarenderpage.py
+++ b/n2y/plugins/jinjarenderpage.py
@@ -376,9 +376,7 @@ class JinjaFencedCodeBlock(FencedCodeBlock):
         logger.error(self.error)
 
     def _render_error(self, err, during_render=True):
-        first_pass_output = self.jinja_environment.globals["first_pass_output"]
-        if self.render_count == 1 or during_render and self.render_count == 0 and \
-                not first_pass_output.second_pass_is_requested:
+        if self.render_count == 1 or during_render and self.render_count == 0:
             self._log_jinja_error(err)
 
     def _error_ast(self):


### PR DESCRIPTION
# Describe Your Changes
Before, we were deciding whether or not to render errors based on whether a second pass was requested. As `first_pass_output` isn't a block-specific variable, this was stopping blocks that needed to render an error from doing so just because a previous block requested a second pass.

# How Did You Test It
I rendered a document where this logic was blocking an error log and made sure that said error log was rendered (see documents 1 & 2.

## Document 1 (the Software Validation Report before this change):
[DOC-0139_Software_Validation_Report-75f95950-b49b-4327-b2c8-f9461d1ece90.docx](https://github.com/innolitics/n2y/files/12717594/DOC-0139_Software_Validation_Report-75f95950-b49b-4327-b2c8-f9461d1ece90.docx)

## Document 2 (the Software Validation Report after this change)
[page.docx](https://github.com/innolitics/n2y/files/12717595/page.docx)
