### PR TITLE
Handle header trees starting with a non-H1 header 

### DIFF
--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -226,13 +226,23 @@ class TableOfContentsBlock(Block):
         if self.subheaders is not None:
             children: list[TableOfContentsItemBlock] = []
             subsections: list[list[Header]] = []
+            # Sometimes, the first header is not an H1, so we need to find the first
+            base: int = self.subheaders[0][0]
             index: int = -1
             for header in self.subheaders:
-                if header[0] == 1:
+                if header[0] == base:
                     index += 1
                     subsections.append([header])
-                if header[0] > 1:
+                if header[0] > base:
                     subsections[index].append(header)
+                if header[0] < base:
+                    logger.warning(
+                        f'Skipping out-of-order header "{header[1][0]}" in table of'
+                        " contents for page named"
+                        f" {self.page.title.to_plain_text()} ({self.page.notion_url})."
+                        " The base header is an H{base} so all following headers"
+                        " should be H{base} or greater."
+                    )
             for subsection in subsections:
                 notion_data = self.generate_item_block(subsection)
                 children.append(

--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -81,7 +81,9 @@ class Block:
 
     def get_children(self):
         if self.has_children:
-            self.children = self.client.get_child_blocks(self.notion_id, self.page, True)
+            self.children = self.client.get_child_blocks(
+                self.notion_id, self.page, True
+            )
         else:
             self.children = []
 
@@ -316,7 +318,9 @@ class TableOfContentsItemBlock(NumberedListItemBlock, TableOfContentsBlock):
                     )
         for subsection in subsections:
             notion_data = self.generate_item_block(subsection)
-            children.append(TableOfContentsItemBlock(self.client, notion_data, self.page))
+            children.append(
+                TableOfContentsItemBlock(self.client, notion_data, self.page)
+            )
         if children:
             self.has_children = True
         self.children = children
@@ -666,7 +670,11 @@ class RowBlock(Block):
             pandoc = self.filter_linebreaks(pandoc)
             cells.append(
                 Cell(
-                    ("", [], []), AlignDefault(), RowSpan(1), ColSpan(1), [Plain(pandoc)]
+                    ("", [], []),
+                    AlignDefault(),
+                    RowSpan(1),
+                    ColSpan(1),
+                    [Plain(pandoc)],
                 )
             )
         return Row(("", [], []), cells)

--- a/n2y/config.py
+++ b/n2y/config.py
@@ -83,7 +83,11 @@ def merge_config(config_items, builtin_defaults, defaults):
         master_defaults_copy = copy.deepcopy(builtin_defaults)
         defaults_copy = copy.deepcopy(defaults)
         config_item_copy = copy.deepcopy(config_item)
-        merged_config_item = {**master_defaults_copy, **defaults_copy, **config_item_copy}
+        merged_config_item = {
+            **master_defaults_copy,
+            **defaults_copy,
+            **config_item_copy,
+        }
         merged_config_items.append(merged_config_item)
     return merged_config_items
 
@@ -122,7 +126,11 @@ def _validate_config_item(config_item):
     if "node_type" not in config_item:
         logger.error("Export config item missing the 'node_type' key")
         return False
-    if config_item["node_type"] not in ["page", "database_as_yaml", "database_as_files"]:
+    if config_item["node_type"] not in [
+        "page",
+        "database_as_yaml",
+        "database_as_files",
+    ]:
         logger.error(
             "Invalid node_type in export config item: %s", config_item["node_type"]
         )

--- a/n2y/errors.py
+++ b/n2y/errors.py
@@ -52,7 +52,9 @@ class HTTPResponseError(N2YError):
 
     def __init__(self, response, message=None) -> None:
         if message is None:
-            message = f"Request to Notion API failed with status: {response.status_code}"
+            message = (
+                f"Request to Notion API failed with status: {response.status_code}"
+            )
         super().__init__(message)
         self.status = response.status_code
         self.headers = response.headers

--- a/n2y/logger.py
+++ b/n2y/logger.py
@@ -1,6 +1,8 @@
 import logging
 
-FORMATTER = logging.Formatter("%(asctime)s - %(levelname)s - n2y.%(module)s: %(message)s")
+FORMATTER = logging.Formatter(
+    "%(asctime)s - %(levelname)s - n2y.%(module)s: %(message)s"
+)
 HANDLER = logging.StreamHandler()
 HANDLER.setFormatter(FORMATTER)
 logging.basicConfig(level=logging.INFO, handlers=[HANDLER])

--- a/n2y/notion.py
+++ b/n2y/notion.py
@@ -92,7 +92,9 @@ class Client:
         notion_classes = {}
         for notion_object, object_types in DEFAULT_NOTION_CLASSES.items():
             if type(object_types) is dict:
-                notion_classes[notion_object] = {k: [v] for k, v in object_types.items()}
+                notion_classes[notion_object] = {
+                    k: [v] for k, v in object_types.items()
+                }
             else:
                 notion_classes[notion_object] = [object_types]
         return notion_classes
@@ -118,7 +120,9 @@ class Client:
             else:
                 raise PluginError(f'Invalid notion object "{notion_object}"')
 
-    def _override_notion_classes(self, notion_object, object_types, default_object_types):
+    def _override_notion_classes(
+        self, notion_object, object_types, default_object_types
+    ):
         # E.g., there are many types of notion blocks but only one type of notion page.
         notion_object_has_types = isinstance(default_object_types, dict)
 

--- a/n2y/notion_mocks.py
+++ b/n2y/notion_mocks.py
@@ -133,7 +133,9 @@ def mock_property_value(property_value_type, content):
 
 
 def mock_rich_text_property_value(text_blocks_descriptors):
-    return mock_property_value("rich_text", mock_rich_text_array(text_blocks_descriptors))
+    return mock_property_value(
+        "rich_text", mock_rich_text_array(text_blocks_descriptors)
+    )
 
 
 def mock_formula_property_value(formula_type, content):

--- a/n2y/plugins/footnotes.py
+++ b/n2y/plugins/footnotes.py
@@ -90,7 +90,9 @@ class TextRichTextWithFootnoteRef(TextRichText):
         pandoc_ast.append(Str(suffix))
 
     def _is_footnote(self):
-        return any(self._footnote_from_token(t) is not None for t in super().to_pandoc())
+        return any(
+            self._footnote_from_token(t) is not None for t in super().to_pandoc()
+        )
 
     def _footnote_from_token(self, token):
         if not isinstance(token, Str):

--- a/n2y/plugins/jinjarenderpage.py
+++ b/n2y/plugins/jinjarenderpage.py
@@ -63,7 +63,9 @@ def join_to(foreign_keys, table, primary_key="notion_id"):
 def list_matches(string, text):
     return list(
         re.finditer(
-            "(?<![a-zA-Z])" + re.escape(_canonicalize(string)) + "(?:s|es)?(?![a-zA-Z])",
+            "(?<![a-zA-Z])"
+            + re.escape(_canonicalize(string))
+            + "(?:s|es)?(?![a-zA-Z])",
             _canonicalize(text),
             re.IGNORECASE,
         )
@@ -267,7 +269,9 @@ class JinjaRenderPage(Page):
         first_pass_output = self.jinja_environment.globals["first_pass_output"]
         if first_pass_output.second_pass_is_requested:
             first_pass_output_text = pandoc_ast_to_markdown(ast)
-            first_pass_output.set_lines(first_pass_output_text.splitlines(keepends=True))
+            first_pass_output.set_lines(
+                first_pass_output_text.splitlines(keepends=True)
+            )
             ast = super().to_pandoc(ignore_toc=True)
             jinja2.clear_caches()
         return ast if ignore_toc else self.generate_toc(ast)
@@ -449,7 +453,11 @@ class JinjaFencedCodeBlock(FencedCodeBlock):
     def to_pandoc(self):
         if self.databases is None:
             self._get_yaml_from_mentions()
-        if self.render_count < 1 or self.render_count < 2 and self.uses_first_pass_output:
+        if (
+            self.render_count < 1
+            or self.render_count < 2
+            and self.uses_first_pass_output
+        ):
             self._render_text()
         if self.error:
             children_ast = self._error_ast()

--- a/tests/test_append_end_to_end.py
+++ b/tests/test_append_end_to_end.py
@@ -16,7 +16,9 @@ def test_append_and_delete_blocks():
         has_children=True,
     )
     del notion_block["url"]
-    creation_response = client.append_child_notion_blocks(page.notion_id, [notion_block])
+    creation_response = client.append_child_notion_blocks(
+        page.notion_id, [notion_block]
+    )
     new_block = creation_response[0]
     assert creation_response
     deletion_response = client.delete_notion_block(new_block)

--- a/tests/test_jinjarenderpage.py
+++ b/tests/test_jinjarenderpage.py
@@ -51,7 +51,9 @@ def test_fuzzy_find_in():
     catch_all_string = "a bc def"
     assert fuzzy_find_in(dict_list, "a", "data") == [{"id": "1", "data": "a"}]
     assert fuzzy_find_in(dict_list, catch_all_string, "data") == reversed_dict_list
-    assert fuzzy_find_in(dict_list, catch_all_string, "data", False) == reversed_dict_list
+    assert (
+        fuzzy_find_in(dict_list, catch_all_string, "data", False) == reversed_dict_list
+    )
     assert fuzzy_find_in(dict_list, catch_all_string, "data", False, False) == dict_list
     assert fuzzy_find_in(dict_list, catch_all_string, "data", True, False) == dict_list
 
@@ -215,7 +217,8 @@ def test_jinja_render_with_incorrect_db_property():
         in markdown
     )
     assert (
-        'the available properties are "title", "notion_id", and "notion_url".' in markdown
+        'the available properties are "title", "notion_id", and "notion_url".'
+        in markdown
     )
 
 
@@ -265,7 +268,9 @@ def test_jinja_render_with_filter_error():
             pandoc_ast = page.to_pandoc()
 
     markdown = pandoc_ast_to_markdown(pandoc_ast)
-    assert 'Recieved the message "type str doesn\'t define __round__ method"' in markdown
+    assert (
+        'Recieved the message "type str doesn\'t define __round__ method"' in markdown
+    )
     assert 'The Jinja filter "round" raised this error' in markdown
     assert 'argument(s): {\n\t"args": (\'a\',),\n\t"kwargs": {}\n}' in markdown
 

--- a/tests/test_linkedheaders.py
+++ b/tests/test_linkedheaders.py
@@ -26,7 +26,9 @@ def mock_header_ast(level, suffix, notion_block):
 
 
 def test_heading_1():
-    notion_block = mock_block("heading_1", {"rich_text": [mock_rich_text("Heading One")]})
+    notion_block = mock_block(
+        "heading_1", {"rich_text": [mock_rich_text("Heading One")]}
+    )
     pandoc_ast, markdown = process_block(notion_block, linked_headers)
     assert pandoc_ast == mock_header_ast(1, "One", notion_block)
     assert markdown == f'# [Heading One]({notion_block["url"]})\n'
@@ -42,7 +44,9 @@ def test_heading_1_bolding_stripped():
 
 
 def test_heading_2():
-    notion_block = mock_block("heading_2", {"rich_text": [mock_rich_text("Heading Two")]})
+    notion_block = mock_block(
+        "heading_2", {"rich_text": [mock_rich_text("Heading Two")]}
+    )
     pandoc_ast, markdown = process_block(notion_block, linked_headers)
     assert pandoc_ast == mock_header_ast(2, "Two", notion_block)
     assert markdown == f'## [Heading Two]({notion_block["url"]})\n'

--- a/tests/test_plugin_dbfootnotes.py
+++ b/tests/test_plugin_dbfootnotes.py
@@ -15,7 +15,9 @@ from n2y.page import Page
 from n2y.plugins.dbfootnotes import PageMentionFootnote
 
 
-def mock_page_mention_with_footnote(mentioned_page_parent, connect_parent_correctly=True):
+def mock_page_mention_with_footnote(
+    mentioned_page_parent, connect_parent_correctly=True
+):
     client = Client("", plugins=["n2y.plugins.dbfootnotes"])
     # The original page, with the footnote ref.
     original_page = mock_page()

--- a/tests/test_rich_text.py
+++ b/tests/test_rich_text.py
@@ -124,7 +124,9 @@ def test_bold_space():
 
 
 def test_italic_spaces():
-    notion_data = mock_rich_text_array([("An", []), (" italic ", ["italic"]), (word, [])])
+    notion_data = mock_rich_text_array(
+        [("An", []), (" italic ", ["italic"]), (word, [])]
+    )
     pandoc_ast, markdown, plain_text = process_rich_text_array(notion_data)
     assert pandoc_ast == [Str("An"), Space(), Emph([Str("italic")]), Space(), Str(word)]
     assert markdown == "An *italic* word.\n"
@@ -188,8 +190,7 @@ def test_blended_annotated_spaces():
         Str("?"),
     ]
     assert (
-        markdown
-        == "**this** ***is*** *a*\n~~test~~[**` did`*"
+        markdown == "**this** ***is*** *a*\n~~test~~[**` did`*"
         "*]{.underline}[` i pass`]{.underline}?\n"
     )
 
@@ -236,8 +237,7 @@ def test_equation_inline():
         Str("indeed"),
     ]
     assert (
-        markdown
-        == "The Schrödinger Equation\n(${\\displaystyle "
+        markdown == "The Schrödinger Equation\n(${\\displaystyle "
         "i\\hbar {\\frac {d}{dt}}\\vert \\Psi (t)\\"
         "rangle={\\hat {H}}\\vert \\Psi (t)\\rangle}$)\nis"
         " a very useful one indeed\n"


### PR DESCRIPTION
# Describe Your Changes
- Avoid `IndexError` when header trees start with a non-H1 header
- Skip out of order headers with a warning
- Add unit test cases

# How Did You Test It
-  Ran `pytest tests` with all tests passing