### PR TITLE
Fix bugs causing our publish-documents workflow to fail

### DIFF
--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -681,12 +681,18 @@ class RowBlock(Block):
 
     def filter_linebreaks(self, ast_list):
         for i, ast in enumerate(ast_list):
+            # A BulletList contains an array of AST arrays, so it wouldn't have a __dict__ attribute
+            if isinstance(ast, list):
+                self.filter_linebreaks(ast)
+                continue
+
             args = ast.__dict__["_args"]
             if len(args) and isinstance(args[0], list):
                 self.filter_linebreaks(args[0])
-            else:
-                if isinstance(ast, LineBreak):
-                    ast_list[i] = Space()
+                continue
+
+            if isinstance(ast, LineBreak):
+                ast_list[i] = Space()
         return ast_list
 
 

--- a/n2y/database.py
+++ b/n2y/database.py
@@ -81,8 +81,15 @@ class Database:
     def parent(self):
         if self.notion_parent["type"] == "workspace":
             return None
-        else:
-            return self.client.get_page(self.notion_parent["page_id"])
+
+        if "page_id" not in self.notion_parent:
+            logger.warning(
+                f"Parent of database {self.title.to_plain_text()} (id: {self.notion_id})"
+                f" has no page_id: {self.notion_parent.items()}"
+            )
+            return None
+
+        return self.client.get_page(self.notion_parent["page_id"])
 
     def to_pandoc(self):
         return self.block.to_pandoc()

--- a/n2y/database.py
+++ b/n2y/database.py
@@ -79,17 +79,22 @@ class Database:
 
     @property
     def parent(self):
-        if self.notion_parent["type"] == "workspace":
+        """
+        The parent of a database can be a page, another database, a block, or
+        it can be at the top level of workspace.
+        """
+        type = self.notion_parent["type"]
+        if type == "workspace":
             return None
 
-        if "page_id" not in self.notion_parent:
-            logger.warning(
-                f"Parent of database {self.title.to_plain_text()} (id: {self.notion_id})"
-                f" has no page_id: {self.notion_parent.items()}"
-            )
-            return None
+        if type == "page_id":
+            return self.client.get_page(self.notion_parent["page_id"])
 
-        return self.client.get_page(self.notion_parent["page_id"])
+        if type == "database_id":
+            return self.client.get_database(self.notion_parent["database_id"])
+
+        if type == "block_id":
+            return self.client.get_block(self.notion_parent["block_id"], page=None)
 
     def to_pandoc(self):
         return self.block.to_pandoc()


### PR DESCRIPTION
# Context
After merging #155, I manually ran the `publish-documents` workflow, which failed with a different error: https://github.com/innolitics/innolitics.github.io/actions/runs/6357254369/job/17268129193

This was due to a `BulletList` being passed [here](https://github.com/innolitics/n2y/blob/8ac2aa97afe7fbf38b1a4eeb654157887de0caae/n2y/blocks.py#L683C8-L684).

To fix this, we first check if the `ast` is an array, and if so, run `filter_linebreaks` on that.

After fixing this, a `KeyError` error occurred in a local run [here](https://github.com/innolitics/n2y/blob/8ac2aa97afe7fbf38b1a4eeb654157887de0caae/n2y/database.py#L85).

~With the fix, it just logs a warning and returns `None`:~

The `KeyError` was caused by the parent page being a database, so the `page_id` key did not exist. The fix checks the `type` (which should be one of: `workspace`, `block_id`, or `page_id`) and returns the appropriate parent (`None` for `workspace`, `database` for `block_id`, and `page` for `page_id`.

# How Did You Test It
- Ran `pytest tests` with all tests passing
- Installed locally and run `n2y publish_config.yml --verbosity=INFO` in the site repo successfully.

