### PR TITLE
pass pandoc options to properties and rich text arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,10 @@ Here are some features we're planning to add in the future:
 
 ## Changelog
 
+### v0.9.0
+- pass the `pandoc_options` setting to wherever `pandoc.write` is called for consistency. Also,
+  this should reasonably be the expected behavior.
+
 ### v0.8.2
 
 - stop filtering linebreaks from table cells

--- a/README.md
+++ b/README.md
@@ -390,6 +390,9 @@ Here are some features we're planning to add in the future:
 
 ## Changelog
 
+### v0.9.1
+- Delete print statement in `rich_text.py`
+
 ### v0.9.0
 - pass the `pandoc_options` setting to wherever `pandoc.write` is called for consistency. Also,
   this should reasonably be the expected behavior.

--- a/n2y/export.py
+++ b/n2y/export.py
@@ -18,6 +18,7 @@ from n2y.utils import (
 def _page_properties(
     page,
     pandoc_format=None,
+    pandoc_options=None,
     id_property=None,
     url_property=None,
     property_map=None,
@@ -26,7 +27,7 @@ def _page_properties(
         pandoc_format = "markdown"
     if property_map is None:
         property_map = {}
-    properties = page.properties_to_values(pandoc_format)
+    properties = page.properties_to_values(pandoc_format, pandoc_options)
     if id_property in properties:
         logger.warning(
             'The id property "%s" is shadowing an existing property with the same name',
@@ -77,6 +78,7 @@ def export_page(
         page_properties = _page_properties(
             page,
             pandoc_format,
+            pandoc_options,
             id_property,
             url_property,
             property_map,
@@ -123,16 +125,14 @@ def database_to_yaml(
 ):
     if content_property in database.schema:
         logger.warning(
-            (
-                'The content property "%s" is shadowing an existing '
-                "property with the same name"
-            ),
+            'The content property "%s" is shadowing an existing '
+            "property with the same name",
             content_property,
         )
     results = []
     for page in database.children_filtered(notion_filter, notion_sorts):
         result = _page_properties(
-            page, pandoc_format, id_property, url_property, property_map
+            page, pandoc_format, pandoc_options, id_property, url_property, property_map
         )
         if content_property:
             pandoc_ast = page.to_pandoc()

--- a/n2y/page.py
+++ b/n2y/page.py
@@ -117,5 +117,8 @@ class Page:
         ast = self.block.to_pandoc()
         return ast if ignore_toc else self.generate_toc(ast)
 
-    def properties_to_values(self, pandoc_format=None):
-        return {k: v.to_value(pandoc_format) for k, v in self.properties.items()}
+    def properties_to_values(self, pandoc_format=None, pandoc_options=None):
+        return {
+            k: v.to_value(pandoc_format, pandoc_options)
+            for k, v in self.properties.items()
+        }

--- a/n2y/plugins/downloadfileproperty.py
+++ b/n2y/plugins/downloadfileproperty.py
@@ -2,13 +2,12 @@ import hashlib
 from os import makedirs, path
 from urllib.parse import urlparse
 
-
 from n2y.property_values import FilesPropertyValue
 from n2y.utils import slugify
 
 
 class DownloadFilePropertyValue(FilesPropertyValue):
-    def to_value(self, _):
+    def to_value(self, _, __):
         url_list = []
         for file in self.files:
             file_content = self.client._get_url(file.url, stream=True)

--- a/n2y/rich_text.py
+++ b/n2y/rich_text.py
@@ -2,17 +2,17 @@ import re
 from collections import deque
 
 from pandoc.types import (
-    Str,
-    Space,
-    LineBreak,
-    Strong,
-    Emph,
-    Strikeout,
     Code,
-    Link,
-    Underline,
-    Math,
+    Emph,
     InlineMath,
+    LineBreak,
+    Link,
+    Math,
+    Space,
+    Str,
+    Strikeout,
+    Strong,
+    Underline,
 )
 
 from n2y.logger import logger
@@ -49,11 +49,11 @@ class RichText:
     def to_pandoc(self):
         raise NotImplementedError()
 
-    def to_value(self, pandoc_format):
+    def to_value(self, pandoc_format, pandoc_options):
         return pandoc_write_or_log_errors(
             self.to_pandoc(),
             format=pandoc_format,
-            options=[],
+            options=pandoc_options,
         )
 
     @classmethod
@@ -211,11 +211,12 @@ class RichTextArray:
     def to_pandoc(self):
         return sum([item.to_pandoc() for item in self.items], [])
 
-    def to_value(self, pandoc_format):
+    def to_value(self, pandoc_format, pandoc_options):
+        print(self.client.export_defaults)
         return pandoc_write_or_log_errors(
             self.to_pandoc(),
             format=pandoc_format,
-            options=[],
+            options=pandoc_options,
         )
 
     def to_plain_text(self):

--- a/n2y/rich_text.py
+++ b/n2y/rich_text.py
@@ -212,7 +212,6 @@ class RichTextArray:
         return sum([item.to_pandoc() for item in self.items], [])
 
     def to_value(self, pandoc_format, pandoc_options):
-        print(self.client.export_defaults)
         return pandoc_write_or_log_errors(
             self.to_pandoc(),
             format=pandoc_format,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ description = "Notion to YAML"
 
 setup(
     name="n2y",
-    version="0.8.2",
+    version="0.9.0",
     description=description,
     long_description=description,
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ description = "Notion to YAML"
 
 setup(
     name="n2y",
-    version="0.9.0",
+    version="0.9.1",
     description=description,
     long_description=description,
     long_description_content_type="text/x-rst",

--- a/tests/test_property_values.py
+++ b/tests/test_property_values.py
@@ -25,7 +25,7 @@ def process_property_value(notion_data, wrap_notion_user):
     else:
         wrap_notion_user.return_value = User(client, mock_user())
     property_value = client.wrap_notion_property_value(notion_data, None)
-    return property_value.to_value("gfm")
+    return property_value.to_value("gfm", [])
 
 
 def test_title():

--- a/tests/test_rich_text.py
+++ b/tests/test_rich_text.py
@@ -1,25 +1,25 @@
 from pandoc.types import (
-    Str,
-    Space,
-    Strong,
-    Emph,
-    Strikeout,
     Code,
+    Emph,
+    InlineMath,
     Link,
     Math,
-    InlineMath,
+    Space,
+    Str,
+    Strikeout,
+    Strong,
     Underline,
 )
 
-from n2y.notion import Client
-from n2y.rich_text import RichTextArray, MentionRichText
 from n2y.mentions import PageMention
+from n2y.notion import Client
 from n2y.notion_mocks import (
-    mock_rich_text_array,
     mock_annotations,
-    mock_rich_text,
     mock_id,
+    mock_rich_text,
+    mock_rich_text_array,
 )
+from n2y.rich_text import MentionRichText, RichTextArray
 
 word = "word."
 spaced_word = " word."
@@ -30,7 +30,7 @@ def process_rich_text_array(notion_data):
     client = Client("")
     rich_text_array = client.wrap_notion_rich_text_array(notion_data)
     pandoc_ast = rich_text_array.to_pandoc()
-    markdown = rich_text_array.to_value("markdown")
+    markdown = rich_text_array.to_value("markdown", [])
     plain_text = rich_text_array.to_plain_text()
     return pandoc_ast, markdown, plain_text
 
@@ -124,9 +124,7 @@ def test_bold_space():
 
 
 def test_italic_spaces():
-    notion_data = mock_rich_text_array(
-        [("An", []), (" italic ", ["italic"]), (word, [])]
-    )
+    notion_data = mock_rich_text_array([("An", []), (" italic ", ["italic"]), (word, [])])
     pandoc_ast, markdown, plain_text = process_rich_text_array(notion_data)
     assert pandoc_ast == [Str("An"), Space(), Emph([Str("italic")]), Space(), Str(word)]
     assert markdown == "An *italic* word.\n"
@@ -190,7 +188,8 @@ def test_blended_annotated_spaces():
         Str("?"),
     ]
     assert (
-        markdown == "**this** ***is*** *a*\n~~test~~[**` did`*"
+        markdown
+        == "**this** ***is*** *a*\n~~test~~[**` did`*"
         "*]{.underline}[` i pass`]{.underline}?\n"
     )
 
@@ -237,7 +236,8 @@ def test_equation_inline():
         Str("indeed"),
     ]
     assert (
-        markdown == "The Schrödinger Equation\n(${\\displaystyle "
+        markdown
+        == "The Schrödinger Equation\n(${\\displaystyle "
         "i\\hbar {\\frac {d}{dt}}\\vert \\Psi (t)\\"
         "rangle={\\hat {H}}\\vert \\Psi (t)\\rangle}$)\nis"
         " a very useful one indeed\n"


### PR DESCRIPTION
# Describe Your Changes
Make the necessary changes to pass each export's `pandoc_options` settings to wherever `pandoc.write` is called for consistency in the exports. Also, this could reasonably be the expected behavior. Also updated the readme and version number.

# How Did You Test It
I updated the tests to pass pandoc_options wherever necessary.