### PR TITLE
Shg/throttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,11 @@ Here are some features we're planning to add in the future:
 
 ## Changelog
 
+### v0.10.1
+- Add the `Client.retry` attribute to determine wether or not API calls should be retried after being rate limited.
+- Remove unshared synced block warning and leave a comment explaining why it was removed.
+- Create the `ConnectionThrottled` exception
+
 ### v0.10.0
 - Instead of importing the logger from the `n2y.logger` module, pass it as an argument wherever
   necessary to allow custom loggers to be used.

--- a/README.md
+++ b/README.md
@@ -391,9 +391,12 @@ Here are some features we're planning to add in the future:
 ## Changelog
 
 ### v0.10.1
-- Add the `Client.retry` attribute to determine wether or not API calls should be retried after being rate limited.
+- Remove the `104` error status code from the list of error status codes that initate a retry in the
+  `retry_api_call` wrapper function.
+- Add the `Client.retry` attribute to determine wether or not API calls should be retried after
+  being rate limited in the `retry_api_call` wrapper function.
 - Remove unshared synced block warning and leave a comment explaining why it was removed.
-- Create the `ConnectionThrottled` exception
+- Create and implement the `ConnectionThrottled` exception
 
 ### v0.10.0
 - Instead of importing the logger from the `n2y.logger` module, pass it as an argument wherever

--- a/n2y/errors.py
+++ b/n2y/errors.py
@@ -29,6 +29,25 @@ class UseNextClass(N2YError):
     pass
 
 
+class ConnectionThrottled(N2YError):
+    """
+    Raised when the connection is throttled by the Notion API.
+    """
+
+    def __init__(self, response, message=None) -> None:
+        retry = response.headers.get("retry-after")
+        self.retry_after = float(retry) if retry else None
+        self.status = response.status_code
+        self.headers = response.headers
+        self.body = response.text
+        if message is None:
+            message = (
+                "Your connection has been throttled by the Notion API for"
+                f" {self.retry_after} seconds. Please try again later."
+            )
+        super().__init__(message)
+
+
 class RequestTimeoutError(N2YError):
     """
     Exception for requests that timeout.

--- a/n2y/errors.py
+++ b/n2y/errors.py
@@ -71,9 +71,7 @@ class HTTPResponseError(N2YError):
 
     def __init__(self, response, message=None) -> None:
         if message is None:
-            message = (
-                f"Request to Notion API failed with status: {response.status_code}"
-            )
+            message = f"Request to Notion API failed with status: {response.status_code}"
         super().__init__(message)
         self.status = response.status_code
         self.headers = response.headers
@@ -107,9 +105,6 @@ class APIErrorCode(str, Enum):
     """Given the bearer token used, the resource does not exist.
     This error can also indicate that the resource has not been shared with owner
     of the bearer token."""
-
-    RateLimited = "rate_limited"
-    """This request exceeds the number of requests allowed. Slow down and try again."""
 
     InvalidJSON = "invalid_json"
     """The request body could not be decoded as JSON."""

--- a/n2y/notion.py
+++ b/n2y/notion.py
@@ -13,6 +13,7 @@ from n2y.emoji import Emoji
 from n2y.errors import (
     APIErrorCode,
     APIResponseError,
+    ConnectionThrottled,
     HTTPResponseError,
     ObjectNotFound,
     PluginError,
@@ -451,6 +452,8 @@ class Client:
                 code = None
             if code == APIErrorCode.ObjectNotFound:
                 raise ObjectNotFound(response, body["message"])
+            elif code == "rate_limited":
+                raise ConnectionThrottled(error.response)
             elif code and is_api_error_code(code):
                 raise APIResponseError(response, body["message"], code)
             raise HTTPResponseError(error.response)

--- a/n2y/notion.py
+++ b/n2y/notion.py
@@ -71,11 +71,13 @@ class Client:
         plugins=None,
         export_defaults=None,
         logger=log,
+        retry=True,
     ):
         self.access_token = access_token
         self.media_root = media_root
         self.media_url = media_url
         self.logger = logger
+        self.retry = retry
         self.export_defaults = export_defaults or merge_default_config({})
 
         self.base_url = "https://api.notion.com/v1/"

--- a/n2y/utils.py
+++ b/n2y/utils.py
@@ -312,7 +312,7 @@ def retry_api_call(api_call):
         try:
             return api_call(*args, **kwargs)
         except HTTPResponseError as err:
-            should_retry = err.status in [409, 429, 500, 502, 504, 503, 104]
+            should_retry = err.status in [409, 429, 500, 502, 504, 503]
             if not should_retry:
                 raise err
             elif retry_count < max_api_retries:

--- a/n2y/utils.py
+++ b/n2y/utils.py
@@ -299,10 +299,15 @@ def load_yaml(data):
 
 
 def retry_api_call(api_call):
+    """
+    Retry an API call if it fails due to a rate limit or server error. Can only be used to
+    decorate methods of the `Client` class.
+    """
     max_api_retries = 4
 
     @functools.wraps(api_call)
     def wrapper(*args, retry_count=0, **kwargs):
+        client = args[0]
         assert "retry_count" not in kwargs, "retry_count is a reserved keyword"
         try:
             return api_call(*args, **kwargs)
@@ -312,10 +317,9 @@ def retry_api_call(api_call):
                 raise err
             elif retry_count < max_api_retries:
                 retry_count += 1
-                log = args[0].logger if args and hasattr(args[0], "logger") else logger
-                if "retry-after" in err.headers:
+                if client.retry and "retry-after" in err.headers:
                     retry_after = float(err.headers["retry-after"])
-                    log.info(
+                    client.logger.info(
                         "This API call has been rate limited and "
                         "will be retried in %f seconds. Attempt %d of %d.",
                         retry_after,
@@ -324,7 +328,7 @@ def retry_api_call(api_call):
                     )
                 else:
                     retry_after = 2
-                    log.info(
+                    client.logger.info(
                         "This API call failed and "
                         "will be retried in %f seconds. Attempt %d of %d.",
                         retry_after,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ description = "Notion to YAML"
 
 setup(
     name="n2y",
-    version="0.10.0",
+    version="0.10.1",
     description=description,
     long_description=description,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
# Describe Your Changes
- Add the `Client.retry` attribute to determine wether or not API calls should be retried after being rate limited.
- Create the `ConnectionThrottled` exception
- Update the readme and setup.py

# How Did You Test It
- Update `retry_api_call` tests to pass a `Client`
- Test that `Client.retry=False` will prevent retries