### PR TITLE
Have the `ConnectionThrottled` exception inherit the `APIResponseError` exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,9 @@ Here are some features we're planning to add in the future:
 
 ## Changelog
 
+### v0.10.2
+- Have the `ConnectionThrottled` exception inherit the `HTTPResponseError` exception and update tests
+
 ### v0.10.1
 - Remove the `104` error status code from the list of error status codes that initate a retry in the
   `retry_api_call` wrapper function.

--- a/n2y/errors.py
+++ b/n2y/errors.py
@@ -29,25 +29,6 @@ class UseNextClass(N2YError):
     pass
 
 
-class ConnectionThrottled(N2YError):
-    """
-    Raised when the connection is throttled by the Notion API.
-    """
-
-    def __init__(self, response, message=None) -> None:
-        retry = response.headers.get("retry-after")
-        self.retry_after = float(retry) if retry else None
-        self.status = response.status_code
-        self.headers = response.headers
-        self.body = response.text
-        if message is None:
-            message = (
-                "Your connection has been throttled by the Notion API for"
-                f" {self.retry_after} seconds. Please try again later."
-            )
-        super().__init__(message)
-
-
 class RequestTimeoutError(N2YError):
     """
     Exception for requests that timeout.
@@ -84,6 +65,25 @@ class APIResponseError(HTTPResponseError):
     def __init__(self, response, message, code) -> None:
         super().__init__(response, f"{message} [{code}]")
         self.code = code
+
+
+class ConnectionThrottled(APIResponseError):
+    """
+    Raised when the connection is throttled by the Notion API.
+    """
+
+    def __init__(self, response, message=None) -> None:
+        retry = response.headers.get("retry-after")
+        self.retry_after = float(retry) if retry else None
+        self.status = response.status_code
+        self.headers = response.headers
+        self.body = response.text
+        if message is None:
+            message = (
+                "Your connection has been throttled by the Notion API for"
+                f" {self.retry_after} seconds. Please try again later."
+            )
+        super().__init__(message)
 
 
 class ObjectNotFound(APIResponseError):

--- a/n2y/errors.py
+++ b/n2y/errors.py
@@ -67,7 +67,7 @@ class APIResponseError(HTTPResponseError):
         self.code = code
 
 
-class ConnectionThrottled(APIResponseError):
+class ConnectionThrottled(HTTPResponseError):
     """
     Raised when the connection is throttled by the Notion API.
     """
@@ -75,15 +75,12 @@ class ConnectionThrottled(APIResponseError):
     def __init__(self, response, message=None) -> None:
         retry = response.headers.get("retry-after")
         self.retry_after = float(retry) if retry else None
-        self.status = response.status_code
-        self.headers = response.headers
-        self.body = response.text
         if message is None:
             message = (
                 "Your connection has been throttled by the Notion API for"
                 f" {self.retry_after} seconds. Please try again later."
             )
-        super().__init__(message)
+        super().__init__(response, message)
 
 
 class ObjectNotFound(APIResponseError):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ description = "Notion to YAML"
 
 setup(
     name="n2y",
-    version="0.10.1",
+    version="0.10.2",
     description=description,
     long_description=description,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
# Describe Your Changes
Have the `ConnectionThrottled` exception inherit the `APIResponseError` exception

# How Did You Test It
I updated the tests to use the `ConnectionThrottled` whenever possible