### PR TITLE
Write `ExpandingLinkToPageBlock._get_child_blocks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,13 @@ Here are some features we're planning to add in the future:
 
 ## Changelog
 
+### v0.10.3
+- Add `_get_child_blocks` to the `ExpandingLinkToPageBlock` in the `expandlinktopages.py`
+  plugin and implement it to patch the `Client.get_child_blocks` inside of the `to_pandoc` method.
+  This sets the `page` argument to the `self.page` of the `ExpandingLinkToPageBlock` instance,
+  making sure that the parent page of the blocks on the linked page is set to the parent page of
+  the `ExpandingLinkToPageBlock` and not the linked page itself.
+
 ### v0.10.2
 - Have the `ConnectionThrottled` exception inherit the `HTTPResponseError` exception and update tests
 

--- a/n2y/plugins/expandlinktopages.py
+++ b/n2y/plugins/expandlinktopages.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from n2y.blocks import LinkToPageBlock
 
 
@@ -11,12 +13,16 @@ class ExpandingLinkToPageBlock(LinkToPageBlock):
         assert self.linked_node_id is not None
 
         if self.link_type == "page_id":
-            page = self.client.get_page(self.linked_node_id)
-            # The `page.block` refers to the ChildPageBlock in the page; we don't
-            # want to call `to_pandoc` on it directly, since we don't want a
-            # full pandoc document, but just the content that would have been in
-            # that document.
-            return page.block.children_to_pandoc()
+            # This `with` statement ensures that the parent page of the blocks on the linked page
+            # is set to the parent page of the `ExpandingLinkToPageBlock` and not the linked page
+            # itself.
+            with patch.object(self.client, "get_child_blocks", self._get_child_blocks()):
+                page = self.client.get_page(self.linked_node_id)
+                # The `page.block` refers to the ChildPageBlock in the page; we don't
+                # want to call `to_pandoc` on it directly, since we don't want a
+                # full pandoc document, but just the content that would have been in
+                # that document.
+                return page.block.children_to_pandoc()
         else:
             # TODO: Might be expanded to handle links to databases as well.
             self.client.logger.warning(
@@ -25,6 +31,21 @@ class ExpandingLinkToPageBlock(LinkToPageBlock):
                 self.page.notion_id,
             )
             return None
+
+    def _get_child_blocks(self):
+        """
+        returns a function that operates like `n2y.notion.Client.get_child_blocks
+        but sets the `page` argument as the `self.page` of this block.
+        """
+
+        def func(block_id, _, get_children):
+            child_notion_blocks = self.client.get_child_notion_blocks(block_id)
+            return [
+                self.client.wrap_notion_block(b, self.page, get_children)
+                for b in child_notion_blocks
+            ]
+
+        return func
 
 
 notion_classes = {


### PR DESCRIPTION
# Describe Your Changes
- Add `_get_child_blocks` to the `ExpandingLinkToPageBlock` in the `expandlinktopages.py` plugin and implement it to patch the `Client.get_child_blocks` inside of the `to_pandoc` method. This sets the `page` argument to the `self.page` of the `ExpandingLinkToPageBlock` instance, making sure that the parent page of the blocks on the linked page is set to the parent page of the `ExpandingLinkToPageBlock` and not the linked page itself
- Update ReadMe in preparation for the new release

# How Did You Test It
N/A