### PR TITLE
Fix: fix broken import for python versions < 3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ build/
 dist/
 .vscode
 venv
+.venv
 .tool-versions
 _debug_pkg

--- a/n2y/errors.py
+++ b/n2y/errors.py
@@ -1,4 +1,13 @@
-from enum import StrEnum
+try:
+    from enum import StrEnum
+except ImportError:
+    # StrEnum introduced in 3.11
+    # StrEnum defined per recommendation here:
+    #   https://docs.python.org/3.10/library/enum.html#others
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
 
 
 class N2YError(Exception):


### PR DESCRIPTION
# Describe Your Changes

Catches import error during StrEnum import, and defines the class by subclassing instead.

# How Did You Test It

By `n2y --help` not throwing an error for 3.10 on my machine.

Closes #188 