### PR TITLE
Add internal link hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Here are some features we're planning to add in the future:
   the `ExpandingLinkToPageBlock` and not the linked page itself.
 - Add the `UniqueIdProperty` class to represent database properties of the "unique_id" type
 - Add the `UniqueIdPropertyValue` class to represent page property values of the "unique_id" type
+- Add `internallinks.py` plugin that adds a resolver for internal links
 
 ### v0.10.2
 - Have the `ConnectionThrottled` exception inherit the `HTTPResponseError` exception and update tests

--- a/n2y/notion_mocks.py
+++ b/n2y/notion_mocks.py
@@ -109,6 +109,18 @@ def mock_block(block_type, content, has_children=False, **kwargs):
     }
 
 
+def mock_heading_block(text_blocks_descriptors, level: int = 1, **kwargs) -> dict:
+    if level not in (1, 2, 3):
+        raise ValueError(f"Invalid heading level: {level}")
+    return mock_block(
+        f"heading_{level}",
+        {
+            "color": "default",
+            "rich_text": mock_rich_text_array(text_blocks_descriptors),
+        }
+    )
+
+
 def mock_paragraph_block(text_blocks_descriptors, **kwargs):
     return mock_block(
         "paragraph",
@@ -133,7 +145,9 @@ def mock_property_value(property_value_type, content):
 
 
 def mock_rich_text_property_value(text_blocks_descriptors):
-    return mock_property_value("rich_text", mock_rich_text_array(text_blocks_descriptors))
+    return mock_property_value(
+        "rich_text", mock_rich_text_array(text_blocks_descriptors)
+    )
 
 
 def mock_formula_property_value(formula_type, content):
@@ -234,7 +248,9 @@ def mock_database(title="Mock Database", extra_properties=None):
     }
 
 
-def mock_comment(text_blocks_descriptors: list[list[str | list[str]]], **kwargs) -> dict:
+def mock_comment(
+    text_blocks_descriptors: list[list[str | list[str]]], **kwargs
+) -> dict:
     date = datetime.now(tz=timezone.utc).isoformat()
     return {
         "id": mock_id(),

--- a/n2y/plugins/internallinks.py
+++ b/n2y/plugins/internallinks.py
@@ -28,11 +28,10 @@ def is_internal_link(href: typing.Optional[str], notion_id: str) -> bool:
 
 
 def find_target_block(page: Page, target_id: str) -> Block:
-    try:
-        page_block: ChildPageBlock = page.block
-    except AttributeError:
-        logger.error(f"page block")
-        raise
+    page_block: ChildPageBlock = page.block
+    if page_block is None:
+        raise ValueError("Page.block is None")
+
     try:
         return next(
             child for child in page_block.children if child.notion_id == target_id
@@ -44,7 +43,7 @@ def find_target_block(page: Page, target_id: str) -> Block:
 
 class NotionInternalLink(TextRichText):
     """ This plugin fixes internal links to headers on the same page.
-    
+
     Instead of leaving the link to point to the original notion source page,
     it substitutes the link to instead be the ID of the header.
     """

--- a/n2y/plugins/internallinks.py
+++ b/n2y/plugins/internallinks.py
@@ -2,10 +2,9 @@ import typing
 import uuid
 import urllib.parse
 
-from n2y.blocks import Block, ChildPageBlock
+from n2y.blocks import Block
 from n2y.errors import UseNextClass
 from n2y.logger import logger
-from n2y.page import Page
 from n2y.rich_text import TextRichText
 from n2y.utils import header_id_from_text
 

--- a/n2y/plugins/internallinks.py
+++ b/n2y/plugins/internallinks.py
@@ -43,6 +43,11 @@ def find_target_block(page: Page, target_id: str) -> Block:
 
 
 class NotionInternalLink(TextRichText):
+    """ This plugin fixes internal links to headers on the same page.
+    
+    Instead of leaving the link to point to the original notion source page,
+    it substitutes the link to instead be the ID of the header.
+    """
 
     def to_pandoc(self):
         if not is_internal_link(self.href, self.block.page.notion_id):

--- a/n2y/plugins/internallinks.py
+++ b/n2y/plugins/internallinks.py
@@ -10,7 +10,7 @@ from n2y.utils import header_id_from_text
 
 
 def get_notion_id_from_href(href: str) -> typing.Optional[str]:
-    """Extract the ID of a target block from a href"""
+    """Extract the ID of a target block from a href fragment"""
     target_id = urllib.parse.urlparse(href, allow_fragments=True).fragment
     if target_id is None:
         return None
@@ -22,7 +22,7 @@ def get_notion_id_from_href(href: str) -> typing.Optional[str]:
         return None
 
 
-def is_internal_link(href: str, notion_id: str) -> bool:
+def is_internal_link(href: typing.Optional[str], notion_id: str) -> bool:
     """Is the href fragment a link to a block on the same page?"""
     return href is not None and href.startswith(f"/{notion_id.replace('-', '')}")
 

--- a/n2y/plugins/internallinks.py
+++ b/n2y/plugins/internallinks.py
@@ -1,0 +1,64 @@
+import typing
+import uuid
+import urllib.parse
+
+from n2y.blocks import Block, ChildPageBlock
+from n2y.logger import logger
+from n2y.page import Page
+from n2y.rich_text import TextRichText
+from n2y.utils import header_id_from_text
+
+
+def get_notion_id_from_href(href: str) -> typing.Optional[str]:
+    """Extract the ID of a target block from a href"""
+    target_id = urllib.parse.urlparse(href, allow_fragments=True).fragment
+    if target_id is None:
+        return None
+    # Convert to UUID and back to ensure the format is correct
+    try:
+        return str(uuid.UUID(target_id))
+    except ValueError:
+        # fragment is not a Notion ID
+        return None
+
+
+def is_internal_link(href: str, notion_id: str) -> bool:
+    """Is the href fragment a link to a block on the same page?"""
+    return href is not None and href.startswith(f"/{notion_id.replace('-', '')}")
+
+
+def find_target_block(page: Page, target_id: str) -> Block:
+    try:
+        page_block: ChildPageBlock = page.block
+    except AttributeError:
+        logger.error(f"page block")
+        raise
+    try:
+        return next(
+            child for child in page_block.children if child.notion_id == target_id
+        )
+    except StopIteration:
+        logger.error(f"Page missing block with target id '{target_id}'")
+        raise
+
+
+class NotionInternalLink(TextRichText):
+
+    def to_pandoc(self):
+        if not is_internal_link(self.href, self.block.page.notion_id):
+            return super().to_pandoc()
+
+        target_id = get_notion_id_from_href(self.href)
+        if target_id is None:
+            logger.warning(
+                "Internal link missing; defaulting to link with no-op behavior"
+            )
+            return super().to_pandoc()
+
+        target_block = find_target_block(self.block.page, target_id)
+        header_id = header_id_from_text(target_block.rich_text.to_plain_text())
+        self.href = f"#{header_id}"
+        return super().to_pandoc()
+
+
+notion_classes = {"rich_texts": {"text": NotionInternalLink}}

--- a/tests/test_plugin_internallinks.py
+++ b/tests/test_plugin_internallinks.py
@@ -96,8 +96,8 @@ def mock_page_with_link_to_header(
 
 def test_find_target_block():
     page, heading, paragraph = mock_page_with_link_to_header()
-    assert find_target_block(page, target_id=heading.notion_id) is heading
-    assert find_target_block(page, target_id=paragraph.notion_id) is paragraph
+    assert find_target_block(page.block, target_id=heading.notion_id) is heading
+    assert find_target_block(page.block, target_id=paragraph.notion_id) is paragraph
 
 
 def test_internal_link_to_pandoc():

--- a/tests/test_plugin_internallinks.py
+++ b/tests/test_plugin_internallinks.py
@@ -26,11 +26,11 @@ def test_get_notion_id_from_href_simple():
 
 
 def test_get_notion_id_from_href_missing_fragment():
-    assert get_notion_id_from_href(f"/1234") is None
+    assert get_notion_id_from_href("/1234") is None
 
 
 def test_get_notion_id_from_href_fragment_is_not_uid():
-    assert get_notion_id_from_href(f"/1234#foo") is None
+    assert get_notion_id_from_href("/1234#foo") is None
 
 
 def test_is_internal_link():

--- a/tests/test_plugin_internallinks.py
+++ b/tests/test_plugin_internallinks.py
@@ -1,0 +1,112 @@
+from unittest.mock import Mock, patch
+
+from n2y.blocks import ChildPageBlock, HeadingOneBlock, ParagraphBlock
+from n2y.notion import Client
+from n2y.notion_mocks import (
+    mock_block,
+    mock_heading_block,
+    mock_id,
+    mock_page,
+    mock_rich_text,
+    mock_user,
+)
+from n2y.page import Page
+from n2y.plugins.internallinks import (
+    find_target_block,
+    get_notion_id_from_href,
+    is_internal_link,
+)
+from n2y.user import User
+from n2y.utils import header_id_from_text, pandoc_ast_to_markdown
+
+
+def test_get_notion_id_from_href_simple():
+    uid = mock_id()
+    assert get_notion_id_from_href(f"/1234#{uid}") == uid
+
+
+def test_get_notion_id_from_href_missing_fragment():
+    assert get_notion_id_from_href(f"/1234") is None
+
+
+def test_get_notion_id_from_href_fragment_is_not_uid():
+    assert get_notion_id_from_href(f"/1234#foo") is None
+
+
+def test_is_internal_link():
+    assert is_internal_link("/1234#5678", "1234")
+
+
+def test_is_not_internal_link():
+    assert not is_internal_link("http://silverspoonscollectors.org/foo#bar", "1234")
+
+
+def test_is_internal_link_missing_href():
+    assert not is_internal_link(None, "1234")
+
+
+@patch("n2y.notion.Client.wrap_notion_user")
+def mock_page_with_link_to_header(
+    wrap_notion_user, header_text: str = "nice header", link_text: str = "nice link"
+) -> Page:
+    client = Client("", plugins=["n2y.plugins.internallinks"])
+    wrap_notion_user.return_value = User(client, mock_user())
+
+    page = Page(client, notion_data=mock_page())
+    page_block = ChildPageBlock(
+        client=client,
+        notion_data=mock_block("child_page", {"title": "Mock Page"}),
+        page=page,
+        get_children=False,
+    )
+    # HACK: should preferably mock Client.get_block, not set private attr
+    page._block = page_block
+
+    heading_block = HeadingOneBlock(
+        client=client,
+        notion_data=mock_heading_block(header_text, level=1),
+        page=page,
+        get_children=False,
+    )
+
+    paragraph_with_link_block = ParagraphBlock(
+        client=client,
+        notion_data=mock_block(
+            "paragraph",
+            {
+                "rich_text": [
+                    mock_rich_text(text="some random text"),
+                    mock_rich_text(
+                        text=link_text,
+                        href=(
+                            f"/{page.notion_id.replace('-', '')}"
+                            f"#{heading_block.notion_id.replace('-', '')}"
+                        ),
+                    ),
+                ]
+            },
+        ),
+        page=page,
+        get_children=False,
+    )
+
+    page.block.children = [heading_block, paragraph_with_link_block]
+    return page, heading_block, paragraph_with_link_block
+
+
+def test_find_target_block():
+    page, heading, paragraph = mock_page_with_link_to_header()
+    assert find_target_block(page, target_id=heading.notion_id) is heading
+    assert find_target_block(page, target_id=paragraph.notion_id) is paragraph
+
+
+def test_internal_link_to_pandoc():
+    header_text = "A Very Fine Title"
+    link_text = "A Very Poor Link Text"
+    page, _, _ = mock_page_with_link_to_header(
+        header_text=header_text,
+        link_text=link_text,
+    )
+    markdown = pandoc_ast_to_markdown(page.to_pandoc(), Mock())
+    assert f"# {header_text}" in markdown
+    assert f"[{link_text}](#{header_id_from_text(header_text)})" in markdown


### PR DESCRIPTION
# Describe Your Changes

This adds a plugin, `internallinks.py`, that fixes broken internal links. Currently if a page has an internal link to a heading contained on that page, the link in the resulting HTML or markdown document points to the original notion source. This PR patches the links to instead be the fragment of the ID of the header.

# How Did You Test It

I added unit tests in this PR, and I checked the `n2y` CLI against a page on the test Notion workspace.