### PR TITLE
Shg/toc debug

### DIFF
--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -267,7 +267,7 @@ class TableOfContentsBlock(Block):
     def generate_item_block(self, section: list[Header]):
         header = section.pop(0)
         header_text = pandoc_write_or_log_errors(
-            header[2], "gfm", [], self.client.logger
+            header[2], "plain", [], self.client.logger
         )[:-1]
         rich_text = mock_rich_text_array([(header_text, None, f"#{header[1][0]}")])
         type_data = {

--- a/n2y/plugins/linkedheaders.py
+++ b/n2y/plugins/linkedheaders.py
@@ -1,6 +1,7 @@
-from n2y.blocks import HeadingBlock
-
 from pandoc.types import Header, Link
+
+from n2y.blocks import HeadingBlock
+from n2y.utils import header_id_from_text
 
 
 class LinkedHeadingBlock(HeadingBlock):
@@ -9,8 +10,9 @@ class LinkedHeadingBlock(HeadingBlock):
     """
 
     def to_pandoc(self):
+        section_id = header_id_from_text(self.rich_text.to_plain_text())
         link = [Link(("", [], []), self.rich_text.to_pandoc(), (self.notion_url, ""))]
-        return Header(self.level, ("", [], []), link)
+        return Header(self.level, (section_id, [], []), link)
 
 
 class LinkedHeadingThreeBlock(LinkedHeadingBlock):

--- a/tests/test_linkedheaders.py
+++ b/tests/test_linkedheaders.py
@@ -2,19 +2,22 @@
 These tests verify how the n2y block classes convert notion data into Pandoc
 abstract syntax tree (AST) objects, and then into markdown.
 """
-from pandoc.types import Str, Space, Header, Link
 
-from n2y.utils import strip_hyphens
+from pandoc.types import Header, Link, Space, Str
+
 from n2y.notion_mocks import mock_block, mock_rich_text
+from n2y.utils import header_id_from_text, strip_hyphens
 from tests.test_blocks import process_block
 
 linked_headers = ["n2y.plugins.linkedheaders"]
 
 
 def mock_header_ast(level, suffix, notion_block):
+    rich_text = notion_block[notion_block["type"]]["rich_text"][0]["plain_text"]
+    section_id = header_id_from_text(rich_text)
     return Header(
         level,
-        ("", [], []),
+        (section_id, [], []),
         [
             Link(
                 ("", [], []),


### PR DESCRIPTION
# Describe Your Changes
The `n2y.plugin.linkedheader` block caused a bug in `TableOfContentsBlock` rendering (see Screenshot 1). This fixes that 
# How Did You Test It
Manually exporting the page
# Screenshot 1 (Before)
![Screenshot 2024-08-26 at 11 52 36 AM](https://github.com/user-attachments/assets/26cb6bb1-f91a-4e01-8b2e-ed65a2d46018)
# Screenshot 2 (After)
![Screenshot 2024-08-26 at 11 52 14 AM](https://github.com/user-attachments/assets/7b00fac0-f560-4d98-9d07-f8b800f823e5)
