### PR TITLE
Implement changes for allowing link_mention parsing from notion API

### DIFF
--- a/n2y/export.py
+++ b/n2y/export.py
@@ -196,11 +196,13 @@ def database_to_files(
 def write_document(document, path):
     if isinstance(document, bytes):
         file_mode = "wb"
+        encoding = None
     else:
         file_mode = "w"
+        encoding = "utf-8"
     if os.path.dirname(path):
         os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, file_mode) as f:
+    with open(path, file_mode, encoding=encoding) as f:
         f.write(document)
 
 

--- a/n2y/mentions.py
+++ b/n2y/mentions.py
@@ -1,4 +1,4 @@
-from pandoc.types import Str
+from pandoc.types import Str, Link
 from n2y.blocks import RowBlock
 from n2y.rich_text import RichText
 from n2y.utils import process_notion_date, processed_date_to_plain_text
@@ -71,10 +71,21 @@ class LinkPreviewMention(Mention):
 class LinkMentionMention(Mention):
     def __init__(self, client, notion_data, plain_text, block=None):
         super().__init__(client, notion_data, plain_text, block)
-        # TODO: properly implement this
+        lm = notion_data["link_mention"]
+        # Support both url and href
+        self.link = lm.get("url") or lm.get("href")
+        self.text = lm.get("title") or plain_text or self.link
 
     def to_pandoc(self):
-        return [Str("")]
+        return [Link(("", [], []), [Str(self.text)], (self.link, ""))]
+
+    def to_value(self, format, options):
+        if format == "markdown" and self.link:
+            return f"[{self.text}]({self.link})"
+        return self.text
+
+    def to_plain_text(self):
+        return self.text
 
 
 # TODO: Handle template mention

--- a/n2y/notion.py
+++ b/n2y/notion.py
@@ -679,3 +679,15 @@ class Client:
         if class_object is None or type(class_object) is self.notion_classes[cls][-1]:
             return True
         return False
+
+    def get_user_pages(self, page_size=500):
+        """
+        Retrieves a list of all pages accessible to the current logged-in user (ACCESS TOKEN).
+        """
+        url = f"{self.base_url}search"
+        params = {
+            "page_size": page_size,
+            "filter": {"property": "object", "value": "page"},
+        }
+        results = self._paginated_request(self._post_url, url, params)
+        return [self._wrap_notion_page(page) for page in results]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -510,3 +510,20 @@ Yakkity yakkity yakkity yak
             "headers to maintain Markdown spec"
         )
         assert any(expected_blurb in m for m in captured_messages)
+
+
+def test_link_mention_with_page(tmpdir):
+    """
+    Test that a Notion page containing an inline link mention is exported correctly.
+    The page can be seen here:
+    https://fresh-pencil-9f3.notion.site/Simple-Link-Mention-Test-2556bc16d85d80a79f05f39a1932d0a2
+    It contains a single inline link mention: https://example.com/
+    The test checks that the markdown export contains the expected link and plain text fallback.
+    """
+    page_id = "2556bc16d85d80a79f05f39a1932d0a2"
+    document = run_n2y_page(tmpdir, page_id)
+
+    # Check markdown export contains the expected link
+    assert "[Example Domain](https://example.com/)" in document
+    # Check plain text fallback
+    assert "Example Domain" in document

--- a/tests/test_rich_text_mentions.py
+++ b/tests/test_rich_text_mentions.py
@@ -1,0 +1,55 @@
+from pandoc.types import (
+    Link,
+    Str,
+)
+from n2y.notion import Client
+from n2y.notion_mocks import mock_rich_text_array
+from tests.utils import newline_lf
+
+
+def process_rich_text_array(notion_data):
+    client = Client("")
+    rich_text_array = client.wrap_notion_rich_text_array(notion_data)
+    pandoc_ast = rich_text_array.to_pandoc()
+    markdown = rich_text_array.to_value("markdown", [])
+    plain_text = rich_text_array.to_plain_text()
+    return pandoc_ast, markdown, plain_text
+
+
+def test_link_mention():
+    link_text = "Example Site"
+    link_url = "https://example.com"
+
+    expected_ast = [
+        Link(('', [], []), [Str(link_text)], (link_url, '')),
+    ]
+    expected_markdown = f"[{link_text}]({link_url})\n"
+    expected_plain = link_text
+
+    # old shape (url)
+    link_mention_data_old = {
+        "type": "link_mention",
+        "link_mention": {"url": link_url},
+    }
+    notion_data_old = mock_rich_text_array([(link_text, [], None, link_mention_data_old)])
+    pandoc_ast, markdown, plain_text = process_rich_text_array(notion_data_old)
+
+    assert pandoc_ast == expected_ast
+    assert newline_lf(markdown) == expected_markdown
+    assert plain_text == expected_plain
+
+    # new shape (href + title + description)
+    link_mention_data_new = {
+        "type": "link_mention",
+        "link_mention": {
+            "href": link_url,
+            "title": link_text,
+            "description": "A description from Notion metadata",
+        },
+    }
+    notion_data_new = mock_rich_text_array([(link_text, [], None, link_mention_data_new)])
+    pandoc_ast, markdown, plain_text = process_rich_text_array(notion_data_new)
+
+    assert pandoc_ast == expected_ast
+    assert newline_lf(markdown) == expected_markdown
+    assert plain_text == expected_plain

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -51,4 +51,7 @@ def parse_yaml_front_matter(content):
 
 
 def newline_lf(input):
+    # Windows uses \r\n (carriage return + newline) for line breaks.
+    # Linux/macOS and Pandoc use only \n.
+    # If your tests compare strings like Markdown output, and Pandoc always produces \n, then your Windows-generated strings with \r\n would fail the equality check.
     return input.replace("\r\n", "\n")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,5 +53,6 @@ def parse_yaml_front_matter(content):
 def newline_lf(input):
     # Windows uses \r\n (carriage return + newline) for line breaks.
     # Linux/macOS and Pandoc use only \n.
-    # If your tests compare strings like Markdown output, and Pandoc always produces \n, then your Windows-generated strings with \r\n would fail the equality check.
+    # If your tests compare strings like Markdown output, and Pandoc always produces \n,
+    # then your Windows-generated strings with \r\n would fail the equality check.
     return input.replace("\r\n", "\n")


### PR DESCRIPTION
… to Pandoc
# Describe Your Changes

Implemented support for parsing link_mention objects from the Notion API into Pandoc.

Added a helper method get_user_pages in n2y/notion.py to retrieve user pages.

Added an end-to-end test test_link_mention_with_page in tests/test_rich_text_mentions.py.

#How Did You Test It

Created unit tests with mock data to validate Pandoc AST, Markdown, and plain-text conversions.

Added an end-to-end integration test against a real Notion page to ensure link_mention is parsed and exported correctly.