### PR TITLE
Mermaid scaling to increse the quality of the genrated PNG files

### DIFF
--- a/n2y/plugins/mermaid.py
+++ b/n2y/plugins/mermaid.py
@@ -12,9 +12,9 @@ from n2y.errors import UseNextClass
 
 mermaid_config = {
     "flowchart": {"useMaxWidth": True},   # Forces diagrams to use available width
-    "theme": "default",
+    "theme": "base",
     "themeVariables": {
-        "fontSize": "30px",               # increases default font size for readability
+        "fontSize": "30px",               # increases base font size for readability
         "lineColor": "#000000",         # effects color of connecting lines in diagrams
         "borderColor": "#000000",       # black border color for nodes to provide clear contrast
         "textColor": "#000000",         # sets text color globally to black for better readability


### PR DESCRIPTION
Mermaid scaling to increse the quality of the genrated PNG files

# Link to issue 
https://www.notion.so/medtech-os/Mermaid-Diagram-Export-Resolution-25ff235c3b48809b9976ea0bb23d7a1f

# Describe Your Changes
We have updated the configurations settings while genrating the PNG output.
Initially , the output PNG was not so readable and clear in the output DOCX file because of the way the MS Word renderizes the mermaid diagram.

The first step i.e mermaid_config plays a crucial role and controls  the structure and how the diagram looks.
Hence , we set up some theme variables that affect the various visual aspects of mermaid flowchart and configured it to use full available width to enhance clarity

The pupeeter config renders the image in a headless browser and I added the scaling factor in its config so that it renders the
mermaid diagram into a image with high pixel density.

Finally , before showing the final output PNG to the user , I added a scaling factor of 3 , which acts as a "zooming" factor
and enhances readability of the output image.


# How Did You Test It
We have tested it on local machine using diffrent mermaid digrams from the notion page  


[notion_export_png.docx](https://github.com/user-attachments/files/23325728/notion_export_png.docx)
