### PR TITLE
Fix heading_4 block mapping to HeadingThreeBlock

### DIFF
--- a/n2y/blocks.py
+++ b/n2y/blocks.py
@@ -973,6 +973,7 @@ DEFAULT_BLOCKS = {
     "heading_1": HeadingOneBlock,
     "heading_2": HeadingTwoBlock,
     "heading_3": HeadingThreeBlock,
+    "heading_4": HeadingThreeBlock,
     "bulleted_list_item": BulletedListItemBlock,
     "numbered_list_item": NumberedListItemBlock,
     "to_do": ToDoListItemBlock,


### PR DESCRIPTION
# Describe Your Changes

In case an h4 breaks the export, just render it as an h3.

# How Did You Test It

Tested locally; the export did not fail.