### PR TITLE
Retry API calls on transient connection errors

### DIFF
--- a/n2y/utils.py
+++ b/n2y/utils.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from time import sleep
 
 import pandoc
+import requests
 import yaml
 from pandoc.types import Meta, MetaBool, MetaList, MetaMap, MetaString, Space, Str
 from plumbum import ProcessExecutionError
@@ -325,6 +326,22 @@ def retry_api_call(api_call):
         assert "retry_count" not in kwargs, "retry_count is a reserved keyword"
         try:
             return api_call(*args, **kwargs)
+        except requests.exceptions.ConnectionError as err:
+            # Transient network failures (e.g. connection reset by peer during
+            # long pulls with many file downloads) are worth retrying too.
+            if retry_count >= max_api_retries:
+                raise err
+            retry_count += 1
+            retry_after = 2 * retry_count
+            client.logger.info(
+                "This API call failed with a connection error and "
+                "will be retried in %f seconds. Attempt %d of %d.",
+                retry_after,
+                retry_count,
+                max_api_retries,
+            )
+            sleep(retry_after)
+            return wrapper(*args, retry_count=retry_count, **kwargs)
         except APIResponseError as err:
             if err.code not in APIErrorCode.RetryableCodes:
                 raise err

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timedelta, timezone
 from math import isclose
+from unittest.mock import patch
 
 import pytest
+import requests
 from pandoc.types import MetaBool, MetaList, MetaMap, MetaString
 from pytest import raises
 
@@ -122,6 +124,34 @@ def test_retry_api_call_once(code):
 
     assert tester(client)
     assert call_count == 2
+
+
+def test_retry_api_call_connection_error():
+    client = Client(foo_token)
+    call_count = 0
+
+    @retry_api_call
+    def tester(_):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise requests.exceptions.ConnectionError("Connection reset by peer")
+        return True
+
+    with patch("n2y.utils.sleep"):
+        assert tester(client)
+    assert call_count == 2
+
+
+def test_retry_api_call_connection_error_max_retries():
+    client = Client(foo_token)
+
+    @retry_api_call
+    def tester(_):
+        raise requests.exceptions.ConnectionError("Connection reset by peer")
+
+    with patch("n2y.utils.sleep"), raises(requests.exceptions.ConnectionError):
+        tester(client)
 
 
 def test_retry_api_call_max_errors():


### PR DESCRIPTION
Two consecutive full article re-pulls of innolitics.github.io died mid-run with `ConnectionError('Connection reset by peer')` during S3 file downloads (`Client.download_file` → `_get_url`). Those methods are decorated with `@retry_api_call`, but the wrapper only retries Notion rate-limit / retryable API-response errors — a transient transport-level failure kills the whole export.

Now `requests.exceptions.ConnectionError` is retried with linear backoff (2s, 4s, 6s, 8s) up to the same `max_api_retries`. Two unit tests added (retry-then-succeed, and exhaustion re-raises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwuTg4uAA3UCEeiNLqtpdC